### PR TITLE
#164829203 implemented login/register using social media accounts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,28 @@
+export DB_NAME=''
+export DB_USER=''
+export DB_PASSWORD=''
+export DB_HOST=127.0.0.1
+export DB_PORT=5432
+export SECRET_KEY=''
+
+export ALLOWED_URL='['https://ah-centauri-backend-staging.herokuapp.com', 'https://ah-centauri-backend.herokuapp.com/', '127.0.0.1', 'localhost']'
+
+
+# Social Auth Token Keys
+export SOCIAL_AUTH_FACEBOOK_KEY="" # App ID
+export SOCIAL_AUTH_FACEBOOK_SECRET="" # App Secret
+
+export FACEBOOK_ACCESS_TOKEN=""
+export FACEBOOK_ACCESS_TOKEN_SECRET=""
+
+export SOCIAL_AUTH_GOOGLE_OAUTH2_KEY=""
+export SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET=""
+
+export GOOGLE_ACCESS_TOKEN=""
+export GOOGLE_ACCESS_TOKEN_SECRET=""
+
+export SOCIAL_AUTH_TWITTER_KEY=""
+export SOCIAL_AUTH_TWITTER_SECRET=""
+
+export TWITTER_ACCESS_TOKEN=""
+export TWITTER_ACCESS_TOKEN_SECRET=""

--- a/Pipfile
+++ b/Pipfile
@@ -21,6 +21,9 @@ psycopg2 = "*"
 gunicorn = "*"
 psycopg2-binary = "*"
 six = "*"
+social-auth-app-django = "*"
+python-social-auth = "*"
+social-auth-core = "*"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "73b3c9f5ec59c04ae3bb84df074bfe0dd6141b8718880b95eef00803093033b0"
+            "sha256": "e145b5e7d7b89ca550c5ef50ede10596af2ee213c94447bfd53dc3fc021c34a1"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -75,6 +75,14 @@
             "index": "pypi",
             "version": "==1.7.0"
         },
+        "defusedxml": {
+            "hashes": [
+                "sha256:24d7f2f94f7f3cb6061acb215685e5125fbcdc40a857eff9de22518820b0a4f4",
+                "sha256:702a91ade2968a82beb0db1e0766a6a273f33d4616a6ce8cde475d8e09853b20"
+            ],
+            "markers": "python_version >= '3.0'",
+            "version": "==0.5.0"
+        },
         "dj-database-url": {
             "hashes": [
                 "sha256:4aeaeb1f573c74835b0686a2b46b85990571159ffc21aa57ecd4d1e1cb334163",
@@ -84,11 +92,11 @@
         },
         "django": {
             "hashes": [
-                "sha256:275bec66fd2588dd517ada59b8bfb23d4a9abc5a362349139ddda3c7ff6f5ade",
-                "sha256:939652e9d34d7d53d74d5d8ef82a19e5f8bb2de75618f7e5360691b6e9667963"
+                "sha256:7c3543e4fb070d14e10926189a7fcf42ba919263b7473dceaefce34d54e8a119",
+                "sha256:a2814bffd1f007805b19194eb0b9a331933b82bd5da1c3ba3d7b7ba16e06dc4b"
             ],
             "index": "pypi",
-            "version": "==2.1.7"
+            "version": "==2.2"
         },
         "django-cors-middleware": {
             "hashes": [
@@ -141,6 +149,13 @@
                 "sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"
             ],
             "version": "==2.8"
+        },
+        "oauthlib": {
+            "hashes": [
+                "sha256:0ce32c5d989a1827e3f1148f98b9085ed2370fc939bf524c9c851d8714797298",
+                "sha256:3e1e14f6cde7e5475128d30e97edc3bfb4dc857cb884d8714ec161fdbb3b358e"
+            ],
+            "version": "==3.0.1"
         },
         "psycopg2": {
             "hashes": [
@@ -222,6 +237,23 @@
             "index": "pypi",
             "version": "==1.7.1"
         },
+        "python-social-auth": {
+            "hashes": [
+                "sha256:6986220df76934aee15c54938a13ebe370a1976e043af01fa3bea417f6722e74",
+                "sha256:8aac8531f7dd4d1b9af606654532fef4f615cb437774a7a1f8dcdebe89c17664",
+                "sha256:9aaad6f7bf83fd129620eadaab1e78e63200da61a5d8898fd1aa243686b36575"
+            ],
+            "index": "pypi",
+            "version": "==0.3.6"
+        },
+        "python3-openid": {
+            "hashes": [
+                "sha256:0086da6b6ef3161cfe50fb1ee5cceaf2cda1700019fda03c2c5c440ca6abe4fa",
+                "sha256:628d365d687e12da12d02c6691170f4451db28d6d68d050007e4a40065868502"
+            ],
+            "markers": "python_version >= '3.0'",
+            "version": "==3.1.0"
+        },
         "pytz": {
             "hashes": [
                 "sha256:32b0891edff07e28efe91284ed9c31e123d84bea3fd98e1f72be2508f43ef8d9",
@@ -236,6 +268,13 @@
             ],
             "version": "==2.21.0"
         },
+        "requests-oauthlib": {
+            "hashes": [
+                "sha256:bd6533330e8748e94bf0b214775fed487d309b8b8fe823dc45641ebcd9a32f57",
+                "sha256:d3ed0c8f2e3bbc6b344fa63d6f933745ab394469da38db16bdddb461c7e25140"
+            ],
+            "version": "==1.2.0"
+        },
         "six": {
             "hashes": [
                 "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
@@ -243,6 +282,31 @@
             ],
             "index": "pypi",
             "version": "==1.12.0"
+        },
+        "social-auth-app-django": {
+            "hashes": [
+                "sha256:6d0dd18c2d9e71ca545097d57b44d26f59e624a12833078e8e52f91baf849778",
+                "sha256:9237e3d7b6f6f59494c3b02e0cce6efc69c9d33ad9d1a064e3b2318bcbe89ae3",
+                "sha256:f151396e5b16e2eee12cd2e211004257826ece24fc4ae97a147df386c1cd7082"
+            ],
+            "index": "pypi",
+            "version": "==3.1.0"
+        },
+        "social-auth-core": {
+            "hashes": [
+                "sha256:65122fb4287c70ff7915be0f52150fc1a9b9515eab3c3f0e4cd9dbb2a442a5c3",
+                "sha256:cc871fb4528f7cbba67efdba0bc0f7d7c6eeb92113b0cdc9368dd91ffe965782",
+                "sha256:f9f36dfa6af2823efb35a5ef65dfd02f66c944f389c33c25dd9621f8bb75a7da"
+            ],
+            "index": "pypi",
+            "version": "==3.1.0"
+        },
+        "sqlparse": {
+            "hashes": [
+                "sha256:40afe6b8d4b1117e7dff5504d7a8ce07d9a1b15aeeade8a2d10f130a834f8177",
+                "sha256:7c3dca29c022744e95b547e867cee89f4fce4373f3549ccd8797d8eb52cdb873"
+            ],
+            "version": "==0.3.0"
         },
         "urllib3": {
             "hashes": [

--- a/authors/apps/authentication/models.py
+++ b/authors/apps/authentication/models.py
@@ -75,6 +75,8 @@ class User(AbstractBaseUser, PermissionsMixin):
     # falsed.
     is_staff = models.BooleanField(default=False)
 
+    is_verified = models.BooleanField(default=False)
+
     # A timestamp representing when this object was created.
     created_at = models.DateTimeField(auto_now_add=True)
 

--- a/authors/apps/authentication/serializers.py
+++ b/authors/apps/authentication/serializers.py
@@ -1,3 +1,5 @@
+from abc import ABC
+
 from django.contrib.auth import authenticate
 
 from rest_framework import serializers
@@ -34,7 +36,6 @@ class LoginSerializer(serializers.Serializer):
     email = serializers.CharField(max_length=255)
     username = serializers.CharField(max_length=255, read_only=True)
     password = serializers.CharField(max_length=128, write_only=True)
-
 
     def validate(self, data):
         # The `validate` method is where we make sure that the current
@@ -116,7 +117,6 @@ class UserSerializer(serializers.ModelSerializer):
         # `max_length` properties too, but that isn't the case for the token
         # field.
 
-
     def update(self, instance, validated_data):
         """Performs an update on a User."""
 
@@ -143,3 +143,13 @@ class UserSerializer(serializers.ModelSerializer):
         instance.save()
 
         return instance
+
+
+class SocialOAuthSerializer(serializers.Serializer):
+    """
+    Handles serialization and deserialization
+    of the request data of social auth
+    """
+    provider = serializers.CharField(max_length=20, required=True)
+    access_token = serializers.CharField(max_length=255, required=True)
+    access_token_secret = serializers.CharField(max_length=255, allow_blank=True, default="")

--- a/authors/apps/authentication/tests/test_social_auth.py
+++ b/authors/apps/authentication/tests/test_social_auth.py
@@ -1,0 +1,59 @@
+import os
+from django.urls import reverse
+from rest_framework.test import APITestCase, APIClient
+from rest_framework import status
+
+AUTH_URL = reverse('authentication:social')
+
+
+class SocialAuthTest(APITestCase):
+    """
+    Base tet class for social authentication
+    """
+    def setUp(self):
+        self.client = APIClient()
+
+    def authenticate(self, provider=os.environ.get('SOCIAL_PROVIDER'),
+                     access_token_secret=os.environ.get('ACCESS_TOKEN_SECRET'),
+                     access_token=os.environ.get('ACCESS_TOKEN')):
+        payload = {
+            'access_token': access_token,
+            'provider': provider,
+            "access_token_secret": access_token_secret
+        }
+        return self.client.post(AUTH_URL, payload)
+
+    def test_user_authenticated_successfully(self):
+        """test user is authenticated successfully with all
+        correct parameters"""
+        res = self.authenticate()
+
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+
+    def test_provider_not_in_payload(self):
+        """Test that the OAuth provider is included in request."""
+        res = self.authenticate(provider='')
+
+        self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_invalid_provider(self):
+        """Test given a none existent provider, should only be
+            google-oauth2, facebook, twitter
+        """
+        res = self.authenticate(provider='google')
+        self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertDictEqual(res.data, {
+            "errors": "Provider not supported, Please use 'google-oauth2','facebook', or 'twitter'."
+        })
+
+    def test_invalid_access_token_in_payload(self):
+        """Test tha OAuth access token is provided"""
+        res = self.authenticate(access_token='dgfhdf',
+                                access_token_secret='gfdtetrtr')
+
+        self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertDictEqual(res.data, {
+            "errors": "Your credentials aren't allowed"
+        })
+
+

--- a/authors/apps/authentication/urls.py
+++ b/authors/apps/authentication/urls.py
@@ -1,7 +1,10 @@
 from django.urls import path
 
 from .views import (
-    LoginAPIView, RegistrationAPIView, UserRetrieveUpdateAPIView
+    LoginAPIView,
+    RegistrationAPIView,
+    UserRetrieveUpdateAPIView,
+    SocialOAuthAPIView
 )
 
 app_name = 'authentication'
@@ -10,4 +13,5 @@ urlpatterns = [
     path('user/', UserRetrieveUpdateAPIView.as_view(), name='get'),
     path('users/', RegistrationAPIView.as_view(), name='register'),
     path('users/login/', LoginAPIView.as_view(), name='login'),
+    path('users/social/', SocialOAuthAPIView.as_view(), name='social'),
 ]

--- a/authors/apps/authentication/views.py
+++ b/authors/apps/authentication/views.py
@@ -1,12 +1,20 @@
 from rest_framework import status
-from rest_framework.generics import RetrieveUpdateAPIView
+from rest_framework.generics import RetrieveUpdateAPIView, CreateAPIView
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from social_django.utils import load_backend, load_strategy
+
+from social_core.backends.oauth import BaseOAuth1, BaseOAuth2
+from social_core.exceptions import MissingBackend
+
 from .renderers import UserJSONRenderer
 from .serializers import (
-    LoginSerializer, RegistrationSerializer, UserSerializer
+    LoginSerializer,
+    RegistrationSerializer,
+    UserSerializer,
+    SocialOAuthSerializer
 )
 
 
@@ -73,4 +81,75 @@ class UserRetrieveUpdateAPIView(RetrieveUpdateAPIView):
         serializer.save()
 
         return Response(serializer.data, status=status.HTTP_200_OK)
+
+
+class SocialOAuthAPIView(CreateAPIView):
+    # Allow any user (authenticated or not) to hit this endpoint.
+    # Login via social accounts
+    permission_classes = (AllowAny,)
+    renderer_classes = (UserJSONRenderer,)
+    serializer_class = SocialOAuthSerializer
+
+    def create(self, request, *args, **kwargs):
+        """
+        Overide 'create' instead of 'perform-create' to access request
+        the request is necessary for 'load_strategy'
+
+        :param request:
+        :return:
+        """
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        provider = serializer.data.get('provider', None)
+
+        # Check to see if social account is from an authenticated user
+        authenticated_user = request.user if not request.user.is_anonymous else None
+        # By loading `request` to `load_strategy` `social-app-auth-django`
+        # will know to use Django
+        strategy = load_strategy(request)
+
+        # Getting the backend that associates the user's social auth provider
+        # eg Facebook, Twitter and Google
+        try:
+            backend = load_backend(strategy=strategy, name=provider, redirect_uri=None)
+            if isinstance(backend, BaseOAuth1):
+                # Twitter uses OAuth1 and requires an access_token_secret
+                # to be passed in the authentication
+                token = {
+                    'oauth_token': serializer.data['access_token'],
+                    'oauth_token_secret': serializer.data['access_token_secret']
+                }
+            elif isinstance(backend, BaseOAuth2):
+                # OAuth implicit grant type which is used for web
+                # and mobile application, all we have to pass here is
+                # an access_token
+                token = serializer.data['access_token']
+        except MissingBackend:
+            return Response({
+                'errors': "Provider not supported, Please use 'google-oauth2',"
+                          "'facebook', or 'twitter'."""
+            }, status=status.HTTP_400_BAD_REQUEST)
+
+        try:
+            # if authenticated_user is None, social_auth_app will create a new user
+            # else social account will be associated with the user that is passed in.
+            user = backend.do_auth(token, user=authenticated_user)
+
+        except BaseException:
+            # you cannot associate a social account with more than one user
+            return Response({
+                'errors': "Your credentials aren't allowed"
+            }, status=status.HTTP_400_BAD_REQUEST)
+
+        if user and user.is_active:
+            user.is_verified = True
+            user.save()
+            serializer = UserSerializer(user)
+            serializer.instance = user
+
+            return Response(serializer.data, status=status.HTTP_200_OK)
+        else:
+            return Response({'errors': "Social authentication error"},
+                            status=status.HTTP_400_BAD_REQUEST)
 

--- a/authors/settings.py
+++ b/authors/settings.py
@@ -25,7 +25,7 @@ SECRET_KEY = '7pgozr2jn7zs_o%i8id6=rddie!*0f0qy3$oy$(8231i^4*@u3'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = os.environ.get('ALLOWED_URL')
 
 # Application definition
 
@@ -40,6 +40,7 @@ INSTALLED_APPS = [
     'corsheaders',
     'django_extensions',
     'rest_framework',
+    'social_django',
 
     'authors.apps.authentication',
     'authors.apps.core',
@@ -49,12 +50,16 @@ INSTALLED_APPS = [
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
+
     'corsheaders.middleware.CorsMiddleware',
+
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+
+    'social_django.middleware.SocialAuthExceptionMiddleware'
 ]
 
 ROOT_URLCONF = 'authors.urls'
@@ -70,6 +75,9 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
+
+                'social_django.context_processors.backends',
+                'social_django.context_processors.login_redirect',
             ],
         },
     },
@@ -86,10 +94,11 @@ DATABASES = {
         'HOST': os.environ.get('DB_HOST'),
         'NAME': os.environ.get('DB_NAME'),
         'USER': os.environ.get('DB_USER'),
-        'PASSWORD': os.environ.get('DB_PASS')
+        'PASSWORD': os.environ.get('DB_PASS'),
     }
 }
 
+SOCIAL_AUTH_POSTGRES_JSONFIELD = True
 # Password validation
 # https://docs.djangoproject.com/en/1.11/ref/settings/#auth-password-validators
 
@@ -107,6 +116,55 @@ AUTH_PASSWORD_VALIDATORS = [
         'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
     },
 ]
+
+
+# Authentication backends
+# desired authentication backends
+AUTHENTICATION_BACKENDS = (
+    'social_core.backends.google.GoogleOAuth2',
+    'social_core.backends.google.GoogleOAuth',
+    'social_core.backends.twitter.TwitterOAuth',
+    'social_core.backends.facebook.FacebookOAuth2',
+    'social_core.backends.facebook.FacebookAppOAuth2',
+
+    'django.contrib.auth.backends.ModelBackend',
+)
+
+# pipelines
+SOCIAL_AUTH_PIPELINE = (
+    'social_core.pipeline.social_auth.social_details',
+    'social_core.pipeline.social_auth.social_uid',
+    'social_core.pipeline.social_auth.auth_allowed',
+    'social_core.pipeline.social_auth.social_user',
+    'social_core.pipeline.user.get_username',
+    'social_core.pipeline.social_auth.associate_by_email',
+    'social_core.pipeline.user.create_user',
+    'social_core.pipeline.social_auth.associate_user',
+    'social_core.pipeline.social_auth.load_extra_data',
+    'social_core.pipeline.user.user_details',
+)
+
+# The social-auth-app-django has a default namespace "social",
+# to override it, we create a custom namespace:
+SOCIAL_AUTH_URL_NAMESPACE = 'social'
+
+# Authentication Keys
+SOCIAL_AUTH_FACEBOOK_KEY = os.environ.get('SOCIAL_AUTH_FACEBOOK_KEY')
+SOCIAL_AUTH_FACEBOOK_SECRET = os.environ.get('SOCIAL_AUTH_FACEBOOK_SECRET')
+SOCIAL_AUTH_FACEBOOK_SCOPE = ['email']
+SOCIAL_AUTH_FACEBOOK_PROFILE_EXTRA_PARAMS = {
+    "fields": "id, email, name"
+}
+FACEBOOK_EXTENDED_PERMISSIONS = ['email']
+
+SOCIAL_AUTH_GOOGLE_OAUTH2_KEY = os.environ.get('SOCIAL_AUTH_GOOGLE_OAUTH2_KEY')
+SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET = os.environ.get('SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET')
+SOCIAL_AUTH_GOOGLE_SCOPE = ['email', 'username']
+
+
+SOCIAL_AUTH_TWITTER_KEY = os.environ.get('SOCIAL_AUTH_TWITTER_KEY')
+SOCIAL_AUTH_TWITTER_SECRET = os.environ.get('SOCIAL_AUTH_TWITTER_SECRET')
+SOCIAL_AUTH_TWITTER_SCOPE = ['email']
 
 # Internationalization
 # https://docs.djangoproject.com/en/1.11/topics/i18n/
@@ -145,5 +203,6 @@ REST_FRAMEWORK = {
         'authors.apps.authentication.backends.JWTAuthentication',
     ),
 }
+
 
 django_heroku.settings(locals())


### PR DESCRIPTION
## What does this PR do?
Enables a new user to login with their pre-existing social media accounts like facebook, twitter and google.

## Description of Task to be completed?
Have social authentication endpoint where users can log in using their social accounts such as google, facebook, and twitter.

### Type of change

- [X] New feature (non-breaking changes which adds functionality)

### How Has This Been Tested?

- [X] End to End
- [X] Integration


## How should this be manually tested?
1.  Clone the repository 
```https://github.com/andela/ah-centauri-backend.git```
2. On completing of clonning
```bash 
cd ah-centauti-backend
git checkout story/#164829203-social-login
```
3. Rename the .env.example file into .env and update the parameters with your own keys.

> For Centauri team members I will share this keys through slack

4. Start development server and send the following through postman
```

_URL: http://127.0.0.1:8000/api/users/social-auth/
BODY: { 
"access_token": "<twitter access token>", 
"access_token_secret": "< twitter secret>", 
"provider": "twitter"
}_

```

## Any background context you want to provide?
![image](https://user-images.githubusercontent.com/33542127/55464273-691e6100-5603-11e9-854a-bebf3bc94274.png)

## What are the relevant pivotal tracker stories?
#164829203