### PR TITLE
#164829212 Users should be able to Favorite articles 

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -180,10 +180,10 @@
         },
         "jinja2": {
             "hashes": [
-                "sha256:74c935a1b8bb9a3947c50a54766a969d4846290e1e788ea44c1392163723c3bd",
-                "sha256:f84be1bb0040caca4cea721fcbbbbd61f9be9464ca236387158b0feea01914a4"
+                "sha256:065c4f02ebe7f7cf559e49ee5a95fb800a9e4528727aec6f24402a5374c65013",
+                "sha256:14dd6caf1527abb21f08f86c784eac40853ba93edb79552aa1e4b8aef1b61c7b"
             ],
-            "version": "==2.10"
+            "version": "==2.10.1"
         },
         "markupsafe": {
             "hashes": [
@@ -241,54 +241,54 @@
         },
         "psycopg2": {
             "hashes": [
-                "sha256:2433931723bf6be4bd342e003ffa9a1cef2cb4de7735d5b063fd554fd64a744c",
-                "sha256:2a0497c8ade1a5a0dc3d62b7f1a4fbcbccfa15d9ef69cce064119cd723566392",
-                "sha256:3ad3cf4732ff7d87dc12031836e5097fc42be767193771da90b8b5038cdca412",
-                "sha256:453c5bc0563c9b9601ef9243c095da9e327f24da6917b7c3ede8e0cd9dd9477d",
-                "sha256:49c5838d90e83217909db3789d30a105385b5e696ec5168cda645546c542f35a",
-                "sha256:6d849117337afd1aa0a74ab9a6c9d2160228d25d5babfa4d9a98bf4a4dad8062",
-                "sha256:8980dbabfb2ed0866b6bd5687d1407c3bccaac1f2f496f1206472108be69b92d",
-                "sha256:a286480430af972be9c30333c48883890dc8d87eab0d591e24975dcf99abff6c",
-                "sha256:bc7ec9ab1f33edd5db40edfb407aabdc92e573c4fcacd9093a9a6f3dd93c7af2",
-                "sha256:d303d9f88ec839a51b430bbec0f4a8314d0d2a53f760e67e95e25e39f6d6fb5f",
-                "sha256:e9836455931ac3d91b71312fa3bb2b9db8c42720a53b7de7db082406e4828585"
+                "sha256:3648afc2b4828a6e00d516d2d09a260edd2c1e3de1e0d41d99c5ab004a73d180",
+                "sha256:5329b4530e31f58e0eafc55e26bbef684509bcc3be41604e45c0b98c297dc722",
+                "sha256:7c1ae1669d11105a002f804bebd7432f8dc7473459aa405164c6b44a922decd5",
+                "sha256:8af13498e32a00d0a66e43b7491c15231b27ab964ee4d2277a4a2dbadfb2c482",
+                "sha256:9d5489867bd5f6d6c6191a4debd8de9a5c03a9608cce3f4d7133e29e6bd4ec27",
+                "sha256:a17bfc9faffcca0ad9360c1ad97ab61ede583aa954715e8e436ffd80046661ff",
+                "sha256:b4a475ce87eabc0607e068a3c704d0aa0820237ed78d493b8e2d880eb73cd7fe",
+                "sha256:c49d66e97affdc80d084b3b363f09f17db621418f0b8e0524b06c54959e2094d",
+                "sha256:d13fbc3d533656cfdf094e13c1b0f40917b72813755ba780971ba0ce04280ac4",
+                "sha256:e1e4fe6e8ab9f9c7d28514d007f623999d2dd6b5b81069dd4f9d30dbdd6f7069",
+                "sha256:e67d60cb1a32f5fd8fcea935cf9efb1d1c26f96203b0ca2ae98c4c40ef8d8eac"
             ],
             "index": "pypi",
-            "version": "==2.8"
+            "version": "==2.8.1"
         },
         "psycopg2-binary": {
             "hashes": [
-                "sha256:0c8cb1b93e25eaf1dfedbcb4cee4ce3860035ce216b71590bda5f8dc99128526",
-                "sha256:1c2eeb074d2be404f22a14c4c71eeaa1a855c940abedf6f726158348e9c83dd6",
-                "sha256:1d879395a5d0dfe191dcfc622dce8b0a5e4fb76d089c903f18a4913e5fbc79c7",
-                "sha256:20d47c61bc9d6a431039f6ceb3b9a34a952a1562cf718054f64c524526fb8ed8",
-                "sha256:39fc9323f065361b99fca7758ac723d7e66bbc7e6ec9c90e398857af0ef61404",
-                "sha256:3c5b7579f3075f19b0b54495d28105049d44564d67b817eef2fa561b2bcf532b",
-                "sha256:3f811db92e30ea2412dfba8e64b18102017646969b5f436138d7b2b38a0e8966",
-                "sha256:41d60c8610a70b6666641b662379ef3b847ad2acd38303d4c8e34efd0f782403",
-                "sha256:45979c708536a3132398863579280657c6bc77e9b9be8b05ba0dae9013b5a0a8",
-                "sha256:4aaa54574b52b85223d3d950b2fc77bd672e6fbb324bb99f834eacbedc4545f7",
-                "sha256:50647aa5f7171153a5f7fa667f99f55468b9b663b997927e4d2e83955b21aa9f",
-                "sha256:528175ab1f12131bb5ea0df64fc524a4c6c51c197dc68d2a9e646029890d4d0f",
-                "sha256:5cbb49cc1c3c4c69ba09a7e18452bd44371b6adad0c9636f117a7554660af529",
-                "sha256:6e2f69635b548147e9b9298f5b67155d212f742683e51d78d24ceec4a3f5464d",
-                "sha256:7994d43431f1b9eba5daa1bdb8f626482cf01e379c00967092c6ebb3e4d3235f",
-                "sha256:86ec556a75f7e0124581100f2c4c8f9c8d67fc6254af4ce500633a77a4ca3207",
-                "sha256:9c32635fca3c250f5a3d2e424819419cd4a0f277c1a383b20fdd95e799d1da7c",
-                "sha256:9e19396065fdbbbc7c0b288a4e70694e1e63593388020fdb86076b12c315bda5",
-                "sha256:a9e7606233fa6c559491758cb319fab6cec25d931cdb5db670c434dde44ab56b",
-                "sha256:c914312ad7c923ac154821fbd591e8482ab03cdb190e14b05e30bf856f69e98c",
-                "sha256:d354ebb06f851f5f2cbc675bbb1369f71091aec6a894986d68341cbca59e7e56",
-                "sha256:d35a25989112c07a994070f1b3c711b19a14209c7608802eced3bcbf07c375bb",
-                "sha256:d71c128151c2d93fab36d7273b6a6696a63e0aa03ba3f7b1b0abb862c2344765",
-                "sha256:d77e4cbecc30f3a8406873c83075c5dae9dcd2ba1c0ffb088edd29372d3df84c",
-                "sha256:dd0b68d212d0992e2a906c6c34a1ef3f82b3dba74ff99744c77f390ffecb0cca",
-                "sha256:f0f97d3e0ab12456733687fc99d05e4de67f12d48a57c3baf1f5a1c6cd76c876",
-                "sha256:f7b72646a5a50aed8535d8cd2d7e915238f389c181d20143f67c2c6527ca5d0e",
-                "sha256:fd06663aa38b2b7b1f71017329545e17f2a583b127de4eeaabdc4cb16cf3a942"
+                "sha256:163d3ee445a0b4c0109877da9e46271aacf4e5e3d60ae7368669555c30f13e7c",
+                "sha256:1af0bfe7b0c13a0e613a27311fd4f9c5d024e8fc0f4b3d284e7df02a58a11fc0",
+                "sha256:2169c3a1bf52d5b30cc98625b5919a964c571a32e8646be20be6c7e3e82079de",
+                "sha256:218f079fa48e2ef812dc3d3ce6ec2f67ac56427ba4b038d5d6331f2cceb489c2",
+                "sha256:26a958930687e94c4c6c73c171e4d4783b82ae4e16aa3424e6bcd4529bceedf0",
+                "sha256:2c7c195aef3acdbc853942bc674844031a732890d2fee88a324298ed376b6c2b",
+                "sha256:2ecdbfed7004669472bfa27c8d51012c717c241c7154ae17e4c8f93024043525",
+                "sha256:345fc31b71a90ada1b51826537917b19a1af685a91c0f066787069c184d7d00f",
+                "sha256:378a06649503f548be5f1e9eec2e94cc1d6138250b82a08dcc6151bca8cec107",
+                "sha256:3f300bf2930e501dde09605de85cb2b84c2638e2c954be02a3c86f28176d3525",
+                "sha256:6c2f66c653ce8bbd7e789d0f7f92c3f9fea881b55226f0ae5ee550cce9e3cf0e",
+                "sha256:6fccbac2633831b877a8fbf865f7082d34895e82a015795a9f80f99a2efe2576",
+                "sha256:7a166f8ccb6888358d3e67795b057540ea7caa71ab9e089b0cb0097f01088965",
+                "sha256:8f6b84f887ec6fef6c1796779f8ec2603dc7e9ef52bc9269de719d4bcbdaebbb",
+                "sha256:92cf3ceb7bb90cf35b8bd993c640b15d4832ba0e142a3b9da5006ef217da595d",
+                "sha256:a20dfdf73f56da674926a3811929cff9fd23b9af90be9a6c36ac246a3486eef3",
+                "sha256:a84415df4689251556c961e4fe3b25d30e32f00faa8064ce0909458dbe0d67b2",
+                "sha256:ab1aa1cd50df3860f624c9713ee9e690eefd4e049d3a4d86577bab6e741e9616",
+                "sha256:abc9dcf85e75a8687f2a6d560c0c1a2593e8e34ba6f9ad6721f8212c5de179a2",
+                "sha256:c10454710a81a2f4b1ff4d1c83ac2cec63e0e55845a56324991514af5b1299d0",
+                "sha256:c38f80719e4dfae7a6311a4f091f07f4fb2fb5d602352015d5639f63f8fabb68",
+                "sha256:d75cf00605630b2cfefa5c62373c605dcda1cc0d607902847dbb8e8e9b67c1ce",
+                "sha256:dce15cb6ef604c9e38fdaa848f58f83153ade9f4aa5e4cf5812aa27163561750",
+                "sha256:e7e0db4311bb76bf3f6e0380f71912cfa6d0be7cc635e3772476050b0dabdabd",
+                "sha256:eac59cae78dfe3fbf7ece25c170d7a152f88df7643381aa5e7344c2028a8d8d4",
+                "sha256:ead7b3e1567bd14cacd44279c5e42cd19f54b9feed39180220253f4fbe3abd56",
+                "sha256:ed772a5e8e7e5dd6bede960a86940c17cf653c7f158dafa5d52e919b676f10ba",
+                "sha256:f2d73131acb94afa45de8b6b8a4bfb21bbe3736633d6478e53247f19dd8c299c"
             ],
             "index": "pypi",
-            "version": "==2.8"
+            "version": "==2.8.1"
         },
         "pyjwt": {
             "hashes": [
@@ -324,10 +324,10 @@
         },
         "pytz": {
             "hashes": [
-                "sha256:32b0891edff07e28efe91284ed9c31e123d84bea3fd98e1f72be2508f43ef8d9",
-                "sha256:d5f05e487007e29e03409f9398d074e158d920d36eb82eaf66fb1136b0c5374c"
+                "sha256:303879e36b721603cc54604edcac9d20401bdbe31e1e4fdee5b9f98d5d31dfda",
+                "sha256:d747dd3d23d77ef44c6a3526e274af6efeb0a6f1afd5a69ba4d5be4098c8e141"
             ],
-            "version": "==2018.9"
+            "version": "==2019.1"
         },
         "requests": {
             "hashes": [
@@ -416,10 +416,10 @@
         },
         "isort": {
             "hashes": [
-                "sha256:08f8e3f0f0b7249e9fad7e5c41e2113aba44969798a26452ee790c06f155d4ec",
-                "sha256:4e9e9c4bd1acd66cf6c36973f29b031ec752cbfd991c69695e4e259f9a756927"
+                "sha256:01cb7e1ca5e6c5b3f235f0385057f70558b70d2f00320208825fa62887292f43",
+                "sha256:268067462aed7eb2a1e237fcb287852f22077de3fb07964e87e00f829eea2d1a"
             ],
-            "version": "==4.3.16"
+            "version": "==4.3.17"
         },
         "lazy-object-proxy": {
             "hashes": [

--- a/authors/apps/articles/models.py
+++ b/authors/apps/articles/models.py
@@ -4,6 +4,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.db import models
 from django.db.models import Avg
 from django.utils.text import slugify
+from django.conf import settings
 
 from authors.apps.authentication.serializers import UserSerializer
 from ..authentication.models import User
@@ -18,14 +19,14 @@ class LikeDislikeManager(models.Manager):
 
     def likes(self):
         """
-        We take the queryset with records greater than 0 because 
+        We take the queryset with records greater than 0 because
         the likes add a negative value
         """
         return self.get_queryset().filter(vote__gt=0).count()
 
     def dislikes(self):
         """
-        We take the queryset with records less than 0 because 
+        We take the queryset with records less than 0 because
         the dislikes add a negative value
         """
         return self.get_queryset().filter(vote__lt=0).count()
@@ -120,3 +121,9 @@ class Ratings(models.Model):
     class Meta:
         ordering = ('-created_at',)
         unique_together = (('author', 'article'),)
+
+
+class Favorite(models.Model):
+    """Implement storage of favorites"""
+    user_id = models.ForeignKey('authentication.User', on_delete=models.CASCADE, related_name='favorites')
+    article_id = models.ForeignKey('articles.articles', on_delete=models.CASCADE, related_name='favorites')

--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -2,6 +2,8 @@ from rest_framework import serializers
 
 from authors.apps.articles.models import Articles, Ratings
 from authors.apps.authentication.serializers import UserSerializer
+from authors.apps.articles.models import Articles, Ratings, Favorite
+from authors.apps.authentication.serializers import UserSerializer
 
 
 class ArticleSerializer(serializers.HyperlinkedModelSerializer):
@@ -80,3 +82,13 @@ class RatingsSerializer(serializers.ModelSerializer):
                 'view_name': 'ratings:rating-detail'
             }
         }
+
+
+class FavoriteSerializer(serializers.ModelSerializer):
+    """
+    Serializers for favorites
+    """
+    class Meta:
+        model = Favorite
+        fields = ('id', 'user_id', 'article_id')
+        read_only_fields = ['id']

--- a/authors/apps/articles/tests/favorites_base_test.py
+++ b/authors/apps/articles/tests/favorites_base_test.py
@@ -1,0 +1,38 @@
+from rest_framework.test import APITestCase, APIClient
+from django.urls import reverse
+from authors.apps.authentication.models import User
+from authors.apps.articles.models import Articles
+
+
+class ArticlesBaseTest(APITestCase):
+    """Sets up tests for features related to articles"""
+
+    def setUp(self):
+        client = APIClient()
+        self.user1 = User.objects.create(
+            username='Kamar', email="dante@gmail.com", password='password')
+        self.user1_token = self.user1.token
+        self.user1.is_verified = True
+        self.user1.save()
+        self.user2 = User.objects.create(
+            username='Dan', email='dankamar@gmail.com', password='password')
+        self.user2_token = self.user2.token
+        self.user2.is_verified = True
+        self.user2.save()
+        self.header_user1 = {
+            'HTTP_AUTHORIZATION': f'Bearer {self.user1_token}'
+        }
+        self.header_user2 = {
+            'HTTP_AUTHORIZATION': f'Bearer {self.user2_token}'
+        }
+        
+        self.article = Articles.objects.create(
+            title='the wheels on the bus',
+            body='go round and round',
+            author=self.user1
+        )
+        self.article.save()
+
+        self.favorite_article_url = '/api/articles/{}/favorite/'.format(self.article.slug)
+        self.get_favorites_url = reverse('articles:get_favorites')
+        self.invalid_favorite_url = '/api/articles/invalid-slug/favorite/'

--- a/authors/apps/articles/tests/test_favorite.py
+++ b/authors/apps/articles/tests/test_favorite.py
@@ -1,0 +1,77 @@
+from rest_framework import status
+from .favorites_base_test import ArticlesBaseTest
+from authors.apps.articles.views import *
+
+
+class FavoriteArticleTestCase(ArticlesBaseTest):
+    """Test favoriting an article functionality"""
+
+    def test_favorite_article(self):
+        """Test favorite article"""
+        response = self.client.post(
+            self.favorite_article_url, **self.header_user1)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        # Test already favorited article
+        response1 = self.client.post(self.favorite_article_url,
+                                    **self.header_user1)
+        detail = "Article already in favorites."
+        self.assertEqual(response1.data.get('errors'), detail)
+        self.assertEqual(response1.status_code, status.HTTP_400_BAD_REQUEST)
+        # Test invalid slug
+        response2 = self.client.post(self.invalid_favorite_url,
+                                    **self.header_user1, format='json')
+        self.assertEqual(response2.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_get_favorite(self):
+        """Test get favorite"""
+        response = self.client.get(self.favorite_article_url,
+                                   **self.header_user1)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.client.post(self.favorite_article_url,
+                         **self.header_user1, format='json')
+        response1 = self.client.get(
+            self.favorite_article_url, **self.header_user1)
+        self.assertEqual(response1.status_code, status.HTTP_200_OK)
+        # Test invalid slug
+        response2 = self.client.get(self.invalid_favorite_url,
+                                   **self.header_user1)
+        detail = "This article has not been found."
+        self.assertEqual(response2.data.get('errors'), detail)
+        self.assertEqual(response2.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_get_favorites(self):
+        """Test get favorites endpoint"""
+        self.client.post(self.favorite_article_url, **self.header_user1)
+        response = self.client.get(self.get_favorites_url,
+                                   **self.header_user1)
+        self.assertEqual(len(response.data.get('favorites')), 1)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_delete_favorite(self):
+        """Test delete favorite"""
+        # test delete favorite that does not exist
+        response = self.client.delete(
+            self.favorite_article_url, **self.header_user1)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.client.post(self.favorite_article_url,
+                         **self.header_user1)
+
+        response1 = self.client.get(
+            self.favorite_article_url, **self.header_user1)
+        self.assertEqual(response1.status_code, status.HTTP_200_OK)
+
+        response2 = self.client.delete(
+            self.favorite_article_url, **self.header_user1)
+        self.assertEqual(response2.status_code, status.HTTP_204_NO_CONTENT)
+        # Test with non existent slug
+        response3 = self.client.delete(self.invalid_favorite_url,
+                                   **self.header_user1)
+        detail = "This article has not been found."
+        self.assertEqual(response3.data.get('errors'), detail)
+        self.assertEqual(response3.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_post_favorite_article_not_found(self):
+        """Test favorite non existent article."""
+        response = self.client.post(self.invalid_favorite_url,
+                                    **self.header_user1, format='json')
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/authors/apps/articles/tests/test_models.py
+++ b/authors/apps/articles/tests/test_models.py
@@ -8,13 +8,13 @@ class ArticleTest(TestCase):
     """ Unit tests for `User` model. """
 
     def setUp(self):
-        User.objects.create_user(
+        self.user = User.objects.create_user(
             username="user",
             email="user@mail.com",
             password="Pa@bbgbh"
         )
         self.article = Articles.objects.create(
-            author_id='1',
+            author=self.user,
             title="the 3 musketeers",
             body="is a timeless story",
             description="not written by me"

--- a/authors/apps/articles/urls.py
+++ b/authors/apps/articles/urls.py
@@ -1,5 +1,6 @@
 from django.urls import path
 
+from authors.apps.articles.views import CreateArticlesAPIView, RetrieveUpdateDeleteArticleAPIView, FavoriteView, GetUserFavoritesView
 from authors.apps.articles.views import (
     CreateArticlesAPIView, RetrieveUpdateDeleteArticleAPIView, LikesView
 )
@@ -22,4 +23,7 @@ urlpatterns = [
     path('articles/<slug:slug>/dislike/',
          LikesView.as_view(model=Articles, vote_type=LikeDislike.DISLIKE),
          name='article_dislike'),
+    path('articles/favorites/me/', GetUserFavoritesView.as_view(), name="get_favorites"),
+    path('articles/<slug:slug>/favorite/', FavoriteView.as_view(), name="favorite"),
+
 ]

--- a/authors/apps/authentication/serializers.py
+++ b/authors/apps/authentication/serializers.py
@@ -166,7 +166,7 @@ class UserSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
         # fields = ('email', 'username', 'password')
-        fields = ('email', 'username', 'password', 'token', 'profile',)
+        fields = ('email', 'username', 'password', 'profile',)
 
         # The `read_only_fields` option is an alternative for explicitly
         # specifying the field with `read_only=True` like we did for password


### PR DESCRIPTION
#### Description
This PR adds the functionality for the user to favorite or unfavorite an article

#### Type of change
- [ ] Bug fix (nonbreaking change which fixes an issue)
- [x] New feature (nonbreaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### How Has This Been Tested?
Please describe the tests that you ran to verify your changes
- [x] End to end
- [x] Integration

#### Checklist:
- [x] My code follows the style guide for this project

#### How should this be manually tested?
1.  Clone the repository 
```https://github.com/andela/ah-centauri-backend.git```
2. On completing of cloning
```bash 
cd ah-centauri-backend
git checkout feature/164829212-user-favourite-articles
```
3. Rename the .env.example file into .env and update the parameters with your own keys.

> For Centauri team members you can use the keys shared through slack

4. Start development server and send the following through postman

**After logging in and creating an article;
Test the following endpoints using postman:**
```
POST /api/articles/<slug>/favorite/ to favorite an article
GET /api/articles/<slug>/favorite/ to test get favorite
DELETE /api/articles/<slug>/favorite/to remove favorite
GET /api/articles/favorites/me/ to test get favorites
```

#### Pivotal Tracker
[#164829212](https://www.pivotaltracker.com/n/projects/2321088/stories/164829212)