### PR TITLE
#165310003 Bug Fix in comment reply count implementation

### DIFF
--- a/authors/apps/comments/models.py
+++ b/authors/apps/comments/models.py
@@ -26,7 +26,7 @@ class Comment(TimeStampModel):
 
     def children(self):
         """
-        Handles retrieving all comments linked to the parent object
+        Handles retrieving all comments linked to the parent object on a specific article.
         :return: [comments]
         """
-        return Comment.objects.filter(parent=self)
+        return Comment.objects.filter(article=self.article, parent=self)


### PR DESCRIPTION
#### Description
Resolving a bug in the get comment reply count.

### Steps to reproduce
1. Login to the application
2. Create 2 articles
3. Comment on each article
4. Reply to an article where the parent is the ID of a comment that is on both articles
5. Then Get comments linked to one article
6. It will show a count that checks all comments where a parent is an ID you replied to hence retrieving comments from different articles where a parent is similar.

### Expected
Should only respond with a reply count of specific articles comments.
How I will go about it is:
Query comments by the parent specified and the article slug.
args:  
```
parent: self, 
article: self.article
```

### Actual
Responds with a reply count of all articles comments where the parent is similar.
How it currently working:
Queries comments by a parent only where:
args:
```parent: self```


#### Type of change
- [x] Bug fix (nonbreaking change which fixes an issue)
- [ ] New feature (nonbreaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### How Has This Been Tested?
Please describe the tests that you ran to verify your changes
- [x] End to end
- [x] Integration

#### Checklist:
- [x] My code follows the style guide for this project
- [x] I have linted my code prior to submission
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

#### Pivotal Tracker
165310003