### PR TITLE
164829214 authenticated users can see author profiles

### DIFF
--- a/authors/apps/articles/models.py
+++ b/authors/apps/articles/models.py
@@ -6,7 +6,8 @@ from django.db.models import Avg
 from django.utils.text import slugify
 from django.conf import settings
 
-from authors.apps.authentication.serializers import UserSerializer
+from authors.apps.profiles.models import Profile
+from authors.apps.profiles.serializers import GetProfileSerializer
 from ..authentication.models import User
 from authors.apps.core.models import TimeStampModel
 
@@ -96,16 +97,14 @@ class Articles(TimeStampModel):
         return 0
 
     def get_author(self):
-        user = UserSerializer(self.author)
+        profile = Profile.objects.get(user=self.author)
+        user = GetProfileSerializer(profile)
         author = {
-            "username": user.data['profile']['username'],
-            "bio": user.data['profile']['bio'],
-            "image": user.data['profile']['image']
+            "username" : user.data['username'],
+            "bio" : user.data['bio'],
+            "image" : user.data['image']
         }
         return author
-
-    class Meta:
-        ordering = ('-created_at',)
 
 
 # add ratings model

--- a/authors/apps/articles/permissions.py
+++ b/authors/apps/articles/permissions.py
@@ -14,3 +14,13 @@ class IsOwnerOrReadOnly(permissions.BasePermission):
 
         # Write permissions are only allowed to the owner of the snippet.
         return obj.author == request.user
+
+class IsVerified(permissions.BasePermission):
+    """
+    Custom permission to only allow verified users
+    to get a list of authors and their profiles. 
+    """
+
+    def has_permission(self, request, view):
+        # REad authors permissions are only allowed to authenticated and verified users
+        return request.user.is_verified

--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -112,8 +112,6 @@ class FavoriteSerializer(serializers.ModelSerializer):
         read_only_fields = ['id']
 
 
-
-
 # add reports serializer
 class ReportsSerializer(serializers.ModelSerializer):
     id = serializers.IntegerField(read_only=True)

--- a/authors/apps/articles/tests/test_get_profiles.py
+++ b/authors/apps/articles/tests/test_get_profiles.py
@@ -1,0 +1,75 @@
+from django.test import TestCase
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from authors.apps.articles.models import Articles
+from authors.apps.authentication.models import User
+
+PROFILES_URL = reverse('articles:author-profile-list')
+
+class AuthorTest(TestCase):
+    """ Unit tests for `User` model. """
+
+    def setUp(self):
+        self.user_riley = User.objects.create(
+            username='Riley',
+            email='riley@mail.com',
+            password='Password123@'
+        )
+        self.user_riley.is_verified = True
+        self.user_riley.save()
+        self.user_token = self.user_riley.token
+
+        self.user_EricK = User.objects.create(
+            username='SteveO',
+            email=')@mail.com',
+            password='password'
+        )
+        self.user_EricK.save()
+        self.user2_token = self.user_EricK.token
+
+        self.client = APIClient()
+        self.headers = {'HTTP_AUTHORIZATION': f'Bearer {self.user_token}'}
+        self.headers2 = {'HTTP_AUTHORIZATION': f'Bearer {self.user2_token}'}
+
+
+        self.article = Articles.objects.create(
+            author=User.objects.first(),
+            title="the 3 musketeers",
+            body="is a timeless story",
+            description="not written by me"
+        )
+
+    def test_get_profiles(self):
+        """
+        Test whether a user can fetch a list of all authors on the platform
+        """
+        response = self.client.get(
+            PROFILES_URL,
+            **self.headers,
+            format='json'
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+
+    def test_get_profiles_no_auth(self):
+        """
+        Test whether an unauthenticated user can view authors
+        """
+        response = self.client.get(
+            PROFILES_URL,
+            format='json'
+        )
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_get_profiles_not_verified(self):
+        """
+        Test whether an unverified user can view authors
+        """
+        response = self.client.get(
+            PROFILES_URL,
+            **self.headers2,
+            format='json'
+        )
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/authors/apps/articles/urls.py
+++ b/authors/apps/articles/urls.py
@@ -1,7 +1,7 @@
 from django.urls import path
 
 from authors.apps.articles.views import CreateArticlesAPIView, RetrieveUpdateDeleteArticleAPIView, FavoriteView, GetUserFavoritesView
-from authors.apps.articles.views import CreateListRatingsAPIView, RetrieveUpdateDeleteRatingAPIView, LikesView
+from authors.apps.articles.views import CreateListRatingsAPIView, RetrieveUpdateDeleteRatingAPIView, LikesView, CreateListAuthorsAPIView
 from authors.apps.articles.views import CreateListReportsAPIView, RetrieveUpdateDeleteReportAPIView, ListReportsAPIView
 from .models import Articles, LikeDislike
 
@@ -29,5 +29,7 @@ urlpatterns = [
          CreateListReportsAPIView.as_view(), name='reports-list'),
     path('articles/reports/<int:pk>/',
          RetrieveUpdateDeleteReportAPIView.as_view(), name='report-detail'),
+    path('articles/authors/profiles/',
+         CreateListAuthorsAPIView.as_view(), name='author-profile-list'),
 
 ]

--- a/authors/apps/authentication/serializers.py
+++ b/authors/apps/authentication/serializers.py
@@ -145,13 +145,22 @@ class LoginSerializer(serializers.Serializer):
         }
 
 
-class UserSerializer(serializers.ModelSerializer):
+class UserSerializer(serializers.HyperlinkedModelSerializer):
     """Handles serialization and deserialization of User objects."""
 
     # Passwords must be at least 8 characters, but no more than 128
     # characters. These values are the default provided by Django. We could
     # change them, but that would create extra work while introducing no real
     # benefit, so let's just stick with the defaults.
+
+    articles = serializers.HyperlinkedRelatedField(
+        many=True,
+        view_name='articles:article',
+        read_only=True,
+        lookup_field='slug'
+
+    )
+
     password = serializers.CharField(
         max_length=128,
         min_length=8,
@@ -162,9 +171,7 @@ class UserSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = User
-        # fields = ('email', 'username', 'password')
-        fields = ('email', 'username', 'password', 'profile',)
-
+        fields = ('email', 'username', 'password', 'profile', 'articles')
         # The `read_only_fields` option is an alternative for explicitly
         # specifying the field with `read_only=True` like we did for password
         # above. The reason we want to use `read_only_fields` here is because

--- a/authors/apps/authentication/tests/test_mail.py
+++ b/authors/apps/authentication/tests/test_mail.py
@@ -53,7 +53,7 @@ class EmailTest(TestCase):
         """Tests that the verification link cannot be used twice"""
         self.sign_up_user()
         link = re.search(
-            r'http:\/\/[a-zA-Z0-9]+\/[a-z]+\/[a-z]+-[a-z]+\/[-0-9a-z]+\/[A-z]+\/',
+            r'http:\/\/[a-zA-Z0-9]+\/[a-z]+\/[a-z]+-[a-z]+\/[-0-9a-z]+\/[A-z]+[0-9]+\/',
             mail.outbox[0].body)
         url = link.group()
         self.client.get(url)

--- a/authors/apps/authentication/views.py
+++ b/authors/apps/authentication/views.py
@@ -134,7 +134,7 @@ class UserRetrieveUpdateAPIView(RetrieveUpdateAPIView):
         # There is nothing to validate or save here. Instead, we just want the
         # serializer to handle turning our `User` object into something that
         # can be JSONified and sent to the client.
-        serializer = self.serializer_class(request.user)
+        serializer = self.serializer_class(request.user, context={'request': request})
 
         return Response(serializer.data, status=status.HTTP_200_OK)
 
@@ -245,7 +245,7 @@ class SocialOAuthAPIView(CreateAPIView):
         if user and user.is_active:
             user.is_verified = True
             user.save()
-            serializer = UserSerializer(user)
+            serializer = UserSerializer(user, context={'request': request})
             serializer.instance = user
 
             return Response(serializer.data, status=status.HTTP_200_OK)


### PR DESCRIPTION
#### Description
When a user is authenticated and verified, he/she should be able to see a list of authors plus their profiles

#### Type of change
- [ ] Bug fix (nonbreaking change which fixes an issue)
- [x] New feature (nonbreaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### How Has This Been Tested?
Please describe the tests that you ran to verify your changes
- [ ] End to end
- [x] Integration

### How can this be manually tested?
1.  Clone the repository 
```https://github.com/andela/ah-centauri-backend.git```

2. cd into project directory and checkout into this branch
```bash 
cd ah-centauri-backend
git checkout feature/164829214-list-users-functionality
```

3. Rename the .env.example file into .env and update the parameters with your own keys.

4. Start development server and send the following through postman

The feature has one endpoint, i.e.
 - `GET` all authors plus their profiles - `/articles/authors/profiles/`

#### Checklist:
- [x] My code follows the style guide for this project
- [ ] I have linted my code prior to submission
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

#### Pivotal Tracker
-ensure authenticated and verified users can see profiles of authors
-write tests for said functionality

[Delivers #164829214]