### PR TITLE
#164829226 Users should be able to see their reading stats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,11 +78,12 @@ target/
 celerybeat-schedule
 
 # dotenv
-.env
+environment.env
 
 # virtualenv
 venv/
 ENV/
+.env
 
 # Spyder project settings
 .spyderproject

--- a/authors/apps/analytics/admin.py
+++ b/authors/apps/analytics/admin.py
@@ -1,0 +1,5 @@
+from django.contrib import admin
+
+from authors.apps.analytics.models import ReadsReport
+
+admin.site.register(ReadsReport)

--- a/authors/apps/analytics/apps.py
+++ b/authors/apps/analytics/apps.py
@@ -1,0 +1,5 @@
+from django.apps import AppConfig
+
+
+class AnalyticsConfig(AppConfig):
+    name = 'authors.apps.analytics'

--- a/authors/apps/analytics/models.py
+++ b/authors/apps/analytics/models.py
@@ -1,0 +1,27 @@
+from django.db import models
+
+from authors.apps.articles.models import Articles
+from authors.apps.authentication.models import User
+from authors.apps.core.models import TimeStampModel
+
+
+class ReadsReport(TimeStampModel):
+    """
+    Implement Views Stats model
+    Display no of users who clicked on an article.
+    """
+    article = models.ForeignKey(Articles, on_delete=models.CASCADE)
+    user = models.ForeignKey(User, on_delete=models.CASCADE)
+    # Shows if user has read the entire article.
+    full_read = models.BooleanField(default=False)
+
+    def __str__(self):
+        """
+        ReadReport String representation
+        :return:
+        """
+        return f'{self.article.slug} viewed by {self.user.username}: ' \
+            f'read entire article == {self.full_read}'
+
+    class Meta:
+        ordering = ['created_at']

--- a/authors/apps/analytics/renderers.py
+++ b/authors/apps/analytics/renderers.py
@@ -1,0 +1,20 @@
+import json
+
+from rest_framework.renderers import JSONRenderer
+
+
+class AnalyticsJSONRenderer(JSONRenderer):
+    charset = 'utf-8'
+
+    def render(self, data, media_type=None, renderer_context=None):
+        # If the view throws an error (such as the user can't be authenticated
+        # or something similar), `data` will contain an `errors` key. We want
+        # the default JSONRenderer to handle rendering errors, so we need to
+        # check for this case.
+
+        if isinstance(data, list):
+            return json.dumps({
+                "views": data,
+                'viewsCount': len(data),
+            })
+        return json.dumps(data)

--- a/authors/apps/analytics/response_messages.py
+++ b/authors/apps/analytics/response_messages.py
@@ -1,0 +1,6 @@
+REPORT_MSG = {
+    "ARTICLE_DOES_NOT_EXIST": "Specified Article does not exist.",
+    "REPORT_UPTO_DATE": "Report Already upto date.",
+    "CAN_NOT_UNREAD": "Can not unread an article.",
+    "READS_REPORT_DOES_NOT_EXIST": "Specified Reed Report does not exist."
+}

--- a/authors/apps/analytics/serializers.py
+++ b/authors/apps/analytics/serializers.py
@@ -1,0 +1,44 @@
+from rest_framework import serializers
+
+from authors.apps.analytics.models import ReadsReport
+
+
+class ReportAPISerializer(serializers.ModelSerializer):
+    article = serializers.SerializerMethodField()
+    user = serializers.ReadOnlyField(source='user.username')
+
+    class Meta:
+        model = ReadsReport
+        fields = ('id', 'user', 'article',
+                  'full_read',)
+        read_only_fields = ('id',)
+
+    def get_article(self, obj):
+        """
+        Return a current user's Viewed articles.
+
+        Params
+        -------
+        request: Object with request data and functions.
+
+        Returns
+        --------
+        Dictionary object:
+        {
+            "title": Viewed article title
+            "description": Viewed article description
+            "slug": Viewed article slug
+            "author": Viewed article author username
+            "created_at": Viewed article date of creation
+        }
+        """
+        all_views = ReadsReport.objects.filter(article=obj.article).count()
+        article = {
+            "title": obj.article.title,
+            "description": obj.article.description,
+            "slug": obj.article.slug,
+            "author": obj.article.author.username,
+            "created_at": str(obj.article.created_at),
+            "totalViews": all_views,
+        }
+        return article

--- a/authors/apps/analytics/tests/baseSetup.py
+++ b/authors/apps/analytics/tests/baseSetup.py
@@ -1,0 +1,56 @@
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+from rest_framework.test import APIClient
+
+from authors.apps.articles.models import Articles
+
+
+class BaseAnalyticsSetup(TestCase):
+    """
+    Test the Analytics model functions and methods
+    """
+
+    def setUp(self):
+        """
+        Set up dummy data for use in the model
+        """
+        self.author = get_user_model().objects.create_user(
+            username="user",
+            email="user@mail.com",
+            password="Pa@bbgbh"
+        )
+        self.author.is_verified = True
+        self.author.save()
+        self.author2 = get_user_model().objects.create_user(
+            username="user2",
+            email="user2@mail.com",
+            password="Pa@bbgbh"
+        )
+        self.author2.save()
+
+        self.client = APIClient()
+
+        self.headers = {
+            'HTTP_AUTHORIZATION': f'Bearer {self.author.token}'}
+        self.headers2 = {
+            'HTTP_AUTHORIZATION': f'Bearer {self.author2.token}'}
+
+        self.article = Articles.objects.create(
+            author_id=self.author.pk,
+            title="the 3 musketeers",
+            body="is a timeless story",
+            description="not written by me",
+            tags=[],
+        )
+        self.report_views_url = reverse("analytics:my_views")
+        self.total_report_views_url = reverse("analytics:total_reads")
+        self.report_url = reverse("analytics:update", args=[self.article.slug])
+        self.article_url = reverse('articles:article', args=[self.article.slug])
+
+    def get_an_article(self):
+        """
+        Handles retrieving a specific article.
+        :return:
+        """
+        return self.client.get(self.article_url, **self.headers, format='json')

--- a/authors/apps/analytics/tests/test_analitics_model.py
+++ b/authors/apps/analytics/tests/test_analitics_model.py
@@ -1,0 +1,27 @@
+from authors.apps.analytics.models import ReadsReport
+from authors.apps.analytics.tests.baseSetup import BaseAnalyticsSetup
+
+
+class TestAnalyticsModel(BaseAnalyticsSetup):
+    """
+    Test the Analytics model functions and methods
+    """
+
+    def test_analytics_model_can_create_report(self):
+        """
+        Test if we can create a report using the report model class
+        """
+        report = ReadsReport.objects.create(user=self.author, article=self.article)
+
+        self.assertEqual(report.article, self.article)
+
+    def test_report_model_string_representation(self):
+        """
+        Test if the string of the report model returns the expected string
+        """
+        report = ReadsReport.objects.create(user=self.author, article=self.article)
+
+        rep = f'{report.article.slug} viewed by {report.user.username}: ' \
+            f'read entire article == {report.full_read}'
+
+        self.assertIn(str(rep), str(report))

--- a/authors/apps/analytics/tests/test_analytics_view.py
+++ b/authors/apps/analytics/tests/test_analytics_view.py
@@ -1,0 +1,137 @@
+from django.urls import reverse
+from rest_framework import status
+
+from authors.apps.analytics.response_messages import REPORT_MSG
+from authors.apps.analytics.tests.baseSetup import BaseAnalyticsSetup
+
+
+class PublicCommentAPiTest(BaseAnalyticsSetup):
+    """
+    Test unauthorized api access
+    """
+
+    def test_auth_required_to_view_user_stats(self):
+        """Test unauthorized user can not view user statistics"""
+        res = self.client.get(self.report_views_url)
+
+        self.assertEqual(res.status_code, status.HTTP_403_FORBIDDEN)
+
+
+class PrivateCommentApiTest(BaseAnalyticsSetup):
+    """
+    Test authorized api access
+    """
+
+    def test_access_analytics_endpoint(self):
+        """
+        Tests user can view all articles viewed or read
+        :return:
+        """
+        res = self.client.get(self.report_views_url, **self.headers, format='json')
+
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+
+    def test_access_analytics_endpoint_if_user_email_is_not_verified(self):
+        """
+        Tests user can not view all articles viewed or read if not verified
+        :return:
+        """
+        res = self.client.get(self.report_views_url, **self.headers2, format='json')
+
+        self.assertEqual(res.status_code, status.HTTP_403_FORBIDDEN)
+
+
+    def test_user_can_view_his_reading_starts(self):
+        """
+        Test can view article user has viewed
+        :return:
+        """
+        article = self.get_an_article()
+
+        res = self.client.get(self.report_views_url, **self.headers, format='json')
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        self.assertEqual(res.data[0]['user'], self.author.username)
+        self.assertEqual(res.data[0]['article']['slug'], self.article.slug)
+
+    def test_user_can_update_article_stats(self):
+        """
+        Test can update on reading an article
+        :return:
+        """
+        article = self.get_an_article()
+
+        payload = {
+            "full_read": True}
+
+        res = self.client.patch(self.report_url, payload, **self.headers, format='json')
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        self.assertTrue(res.data['full_read'])
+
+    def test_user_can_not_unread_an_article(self):
+        """
+        Test can not unread an article
+        :return:
+        """
+        article = self.get_an_article()
+
+        payload = {
+            "full_read": False}
+        res = self.client.patch(self.report_url, payload, **self.headers, format='json')
+
+        self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(res.data['errors'], REPORT_MSG['CAN_NOT_UNREAD'])
+
+    def test_can_not_update_report_if_article_is_invalid(self):
+        """Test retrieving and article where the article is not found"""
+        url = reverse("analytics:update", args=["Not_valid_article"])
+        payload = {
+            "full_read": True
+        }
+        res = self.client.patch(url, payload, **self.headers, format='json')
+
+        self.assertEqual(res.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertDictEqual(res.data, {
+            'errors': REPORT_MSG['ARTICLE_DOES_NOT_EXIST']})
+
+    def test_user_can_not_update_article_stats_as_read_if_already_read(self):
+        """
+        Test can not update an already read article.
+        :return:
+        """
+        article = self.get_an_article()
+
+        payload = {
+            "full_read": True
+        }
+
+        res = self.client.patch(self.report_url, payload, **self.headers, format='json')
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        self.assertTrue(res.data['full_read'])
+
+        res1 = self.client.patch(self.report_url, payload, **self.headers, format='json')
+        self.assertEqual(res1.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertDictEqual(res1.data, {
+            "errors": REPORT_MSG['REPORT_UPTO_DATE']})
+
+    def test_user_can_not_update_article_stats_as_read_if_not_viewed(self):
+        """
+        Test can not update an article if user has not viewed the article.
+        :return:
+        """
+        payload = {
+            "full_read": True
+        }
+
+        res = self.client.patch(self.report_url, payload, **self.headers, format='json')
+        self.assertEqual(res.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertDictEqual(res.data, {
+            "errors": REPORT_MSG['READS_REPORT_DOES_NOT_EXIST']})
+
+    def test_get_all_views_of_my_article(self):
+        """
+        Tests user can not view all articles viewed or read if not verified
+        :return:
+        """
+        res = self.client.get(self.total_report_views_url, **self.headers, format='json')
+
+        self.assertEqual(res.status_code, status.HTTP_200_OK)

--- a/authors/apps/analytics/tests/test_app_file.py
+++ b/authors/apps/analytics/tests/test_app_file.py
@@ -1,0 +1,12 @@
+from django.apps import apps
+from django.test import TestCase
+
+from authors.apps.analytics.apps import AnalyticsConfig
+
+
+class AnalyticsConfigTest(TestCase):
+    """Test the comment application in django on file apps.py"""
+
+    def test_apps(self):
+        self.assertEqual(AnalyticsConfig.name, 'authors.apps.analytics')
+        self.assertEqual(apps.get_app_config('analytics').name, 'authors.apps.analytics')

--- a/authors/apps/analytics/urls.py
+++ b/authors/apps/analytics/urls.py
@@ -1,0 +1,14 @@
+from django.urls import path
+
+from authors.apps.analytics.views import (AnalyticsReportAPIView,
+                                          AnalyticsUpdateReportAPIView,
+                                          AuthorsAnalyticsReportAPIView,
+                                          )
+
+app_name = 'analytics'
+
+urlpatterns = [
+    path('analytics/', AnalyticsReportAPIView.as_view(), name='my_views'),
+    path('analytics/me/', AuthorsAnalyticsReportAPIView.as_view(), name='total_reads'),
+    path('analytics/<slug:slug>/', AnalyticsUpdateReportAPIView.as_view(), name='update'),
+]

--- a/authors/apps/analytics/views.py
+++ b/authors/apps/analytics/views.py
@@ -1,0 +1,109 @@
+from rest_framework import status
+from rest_framework.permissions import (IsAuthenticated, )
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from authors.apps.analytics.models import ReadsReport
+from authors.apps.analytics.renderers import AnalyticsJSONRenderer
+from authors.apps.analytics.response_messages import REPORT_MSG
+from authors.apps.analytics.serializers import ReportAPISerializer
+from authors.apps.articles.models import Articles
+from authors.apps.articles.permissions import IsVerified
+
+
+class AnalyticsReportAPIView(APIView):
+    """
+    Handles viewing of read article analytics
+    Traffic and visitor statistics are available for stories if authenticated
+    """
+    permission_classes = (IsAuthenticated, IsVerified,)
+    serializer_class = ReportAPISerializer
+    renderer_classes = (AnalyticsJSONRenderer,)
+
+    def get(self, request):
+        """
+        Handles listing all report on an article
+
+        :param request:
+        :return: [report]
+        """
+        self.check_permissions(request)
+
+        report = ReadsReport.objects.filter(user=request.user)
+
+        serializer = self.serializer_class(report, many=True)
+
+        return Response(serializer.data,
+                        status=status.HTTP_200_OK)
+
+
+class AuthorsAnalyticsReportAPIView(APIView):
+    """
+    Handles viewing of read article analytics for my articles
+    Traffic and visitor statistics are available for stories if authenticated
+    """
+    permission_classes = (IsAuthenticated, IsVerified,)
+    serializer_class = ReportAPISerializer
+    renderer_classes = (AnalyticsJSONRenderer,)
+
+    def get(self, request):
+        """
+        Handles listing all report on an article
+
+        :param request:
+        :return: [report]
+        """
+        self.check_permissions(request)
+
+        report = ReadsReport.objects.filter(article__author=request.user)
+        serializer = self.serializer_class(report, many=True)
+
+        return Response(serializer.data,
+                        status=status.HTTP_200_OK)
+
+
+class AnalyticsUpdateReportAPIView(APIView):
+    """
+    Handles updating viewing of read article analytics
+    Traffic and visitor statistics are available for stories if authenticated
+    """
+    permission_classes = (IsAuthenticated, IsVerified,)
+    serializer_class = ReportAPISerializer
+    renderer_classes = (AnalyticsJSONRenderer,)
+
+    def patch(self, request, slug):
+        """
+        Handles updating report if author is same as the requester and article is similar
+        :param request:
+        :param slug:
+        :return: [updated report]
+        """
+
+        self.check_permissions(request)
+
+        try:
+            article = Articles.objects.get(slug=slug)
+            report = ReadsReport.objects.get(user=request.user, article=article)
+            if report.full_read is True:
+                return Response({
+                                    "errors": REPORT_MSG['REPORT_UPTO_DATE']},
+                                status=status.HTTP_400_BAD_REQUEST)
+            if request.data['full_read'] != report.full_read:
+                serializer = self.serializer_class(report, data=request.data, partial=True)
+                serializer.is_valid(raise_exception=True)
+                serializer.save()
+
+                return Response(serializer.data, status=status.HTTP_200_OK)
+            return Response({
+                                "errors": REPORT_MSG['CAN_NOT_UNREAD']}, status=status.HTTP_400_BAD_REQUEST)
+        except (Articles.DoesNotExist, ReadsReport.DoesNotExist,) as e:
+            message = ""
+
+            if isinstance(e, Articles.DoesNotExist):
+                message = REPORT_MSG['ARTICLE_DOES_NOT_EXIST']
+
+            elif isinstance(e, ReadsReport.DoesNotExist):
+                message = REPORT_MSG['READS_REPORT_DOES_NOT_EXIST']
+
+            return Response({
+                                "errors": message}, status=status.HTTP_404_NOT_FOUND)

--- a/authors/apps/articles/models.py
+++ b/authors/apps/articles/models.py
@@ -169,4 +169,3 @@ class ReportArticles(TimeStampModel):
 
     class Meta:
         ordering = ('-created_at',)
-

--- a/authors/apps/core/reports.py
+++ b/authors/apps/core/reports.py
@@ -1,0 +1,16 @@
+from authors.apps.analytics.models import ReadsReport
+
+
+def reporting(*args, **kwargs):
+    """
+    Handles reporting of visitors who clicked or read or clapped an article.
+    :param request:
+    :param kwargs:
+    :return: [report]
+    """
+    try:
+        report = ReadsReport.objects.get(user=kwargs.get('user'), article=kwargs.get('article'))
+    except ReadsReport.DoesNotExist:
+        report = ReadsReport.objects.create(user=kwargs.get('user'), article=kwargs.get('article'))
+
+    return report

--- a/authors/settings.py
+++ b/authors/settings.py
@@ -52,7 +52,8 @@ INSTALLED_APPS = [
     'authors.apps.profiles',
     'authors.apps.articles.apps.ArticlesConfig',
     'authors.apps.comments',
-    'authors.apps.bookmarks.apps.BookmarksConfig'
+    'authors.apps.bookmarks.apps.BookmarksConfig',
+    'authors.apps.analytics',
 ]
 
 MIDDLEWARE = [

--- a/authors/urls.py
+++ b/authors/urls.py
@@ -22,5 +22,6 @@ urlpatterns = [
     path('api/', include('authors.apps.profiles.urls', namespace='profiles')),
     path('api/', include('authors.apps.articles.urls', namespace='articles')),
     path('api/', include('authors.apps.comments.urls', namespace='comments')),
-    path('api/', include('authors.apps.bookmarks.urls', namespace='bookmarks'))
+    path('api/', include('authors.apps.bookmarks.urls', namespace='bookmarks')),
+    path('api/', include('authors.apps.analytics.urls', namespace='analytics')),
 ]

--- a/release.sh
+++ b/release.sh
@@ -2,7 +2,8 @@
 echo "Running Release Tasks"
 
 echo "Running Database migrations and migrating the new changes"
-python manage.py makemigrations authentication profiles articles comments bookmarks
+
+python manage.py makemigrations authentication profiles articles comments bookmarks analytics
 python manage.py migrate
 
 echo "Done.."


### PR DESCRIPTION
#### Description
When a user is authenticated and verified, he/she should be able to view the number of visitors who viewed a specific article and their reads.

> reads- How many visitors have read the entire article.

- Users can know how many people read the entire article

#### Type of change
- [ ] Bug fix (nonbreaking change which fixes an issue)
- [x] New feature (nonbreaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### How Has This Been Tested?
Please describe the tests that you ran to verify your changes
- [x] End to end
- [x] Integration

### How can this be manually tested?
1.  Clone the repository 
```https://github.com/andela/ah-centauri-backend.git```

2. cd into project directory and checkout into this branch
```bash 
cd ah-centauri-backend
git checkout feature/164829226-see-reading-stats
```

3. Rename the .env.example file into .env and update the parameters with your own keys.

4. Start development server and send the following through postman

The feature has two endpoints, i.e.
 - `GET` get my reading stats - `/api/analytics/`
 - `PATCH` updating article report full read - `/api/analytics/<slug>/`

#### Checklist:
- [x] My code follows the style guide for this project
- [ ] I have linted my code prior to submission
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

#### Pivotal Tracker
-ensure a users should be able to see their reading stats
-write tests for said functionality

[Delivers #164829226]