### PR TITLE
164829224 users should be able to view their comment edit history

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,6 +4,8 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 
 [dev-packages]
+pep8 = "*"
+autopep8 = "*"
 
 [packages]
 amqp = "==2.4.2"
@@ -54,6 +56,7 @@ whitenoise = "==4.1.2"
 django-taggit = "==1.1.0"
 django-taggit-serializer = "==0.1.7"
 django-filter = "==2.1.0"
+django-simple-history = "*"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a06a1428b70a55f45a523454112acdbc5c3b705600510a2a8f0bc0026c4b10ce"
+            "sha256": "37a1131672e5d94260d65136e6eddf6832591943a88b7716ab933b569c029ae2"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -191,6 +191,14 @@
             ],
             "index": "pypi",
             "version": "==2.6.2"
+        },
+        "django-simple-history": {
+            "hashes": [
+                "sha256:63736301576c04ee4b3a3b28ad17b10a0666b988f6f5ee5990edb29c2de6475d",
+                "sha256:652979d2091cb1230104d930c1e335feb267feb1784c2aa95b5d334a5748b079"
+            ],
+            "index": "pypi",
+            "version": "==2.7.2"
         },
         "django-taggit": {
             "hashes": [
@@ -544,5 +552,28 @@
             "version": "==4.1.2"
         }
     },
-    "develop": {}
+    "develop": {
+        "autopep8": {
+            "hashes": [
+                "sha256:4d8eec30cc81bc5617dbf1218201d770dc35629363547f17577c61683ccfb3ee"
+            ],
+            "index": "pypi",
+            "version": "==1.4.4"
+        },
+        "pep8": {
+            "hashes": [
+                "sha256:b22cfae5db09833bb9bd7c8463b53e1a9c9b39f12e304a8d0bba729c501827ee",
+                "sha256:fe249b52e20498e59e0b5c5256aa52ee99fc295b26ec9eaa85776ffdb9fe6374"
+            ],
+            "index": "pypi",
+            "version": "==1.7.1"
+        },
+        "pycodestyle": {
+            "hashes": [
+                "sha256:95a2219d12372f05704562a14ec30bc76b05a5b297b21a5dfe3f6fac3491ae56",
+                "sha256:e40a936c9a450ad81df37f549d676d127b1b66000a6c500caa2b085bc0ca976c"
+            ],
+            "version": "==2.5.0"
+        }
+    }
 }

--- a/authors/apps/comments/models.py
+++ b/authors/apps/comments/models.py
@@ -2,6 +2,9 @@ from django.db import models
 from django.contrib.contenttypes.fields import GenericRelation
                                                 
 from authors.apps.articles.models import Articles, LikeDislike
+from simple_history.models import HistoricalRecords
+
+from authors.apps.articles.models import Articles
 from authors.apps.authentication.models import User
 from authors.apps.core.models import TimeStampModel
 
@@ -15,6 +18,7 @@ class Comment(TimeStampModel):
     body = models.TextField(max_length=255, null=False, blank=False)
     parent = models.ForeignKey('self', null=True, blank=True, on_delete=models.CASCADE)
     likes = GenericRelation(LikeDislike, related_query_name='comments')
+    history = HistoricalRecords()
 
     def __str__(self):
         """

--- a/authors/apps/comments/response_messages.py
+++ b/authors/apps/comments/response_messages.py
@@ -1,5 +1,5 @@
 COMMENTS_MSG = {
     "ARTICLE_DOES_NOT_EXIST": "Specified Article does not exist.",
-    "COMMENT_DOES_NOT_EXIST": "Specified Article does not exist.",
+    "COMMENT_DOES_NOT_EXIST": "Specified Comment does not exist.",
     "DELETE_SUCCESS": "Deletion successful.",
 }

--- a/authors/apps/comments/serializers.py
+++ b/authors/apps/comments/serializers.py
@@ -13,12 +13,13 @@ class CommentSerializer(serializers.ModelSerializer):
     body = serializers.CharField(max_length=250, required=True)
     likes = serializers.ReadOnlyField(source='likes.likes')
     dislikes = serializers.ReadOnlyField(source='likes.dislikes')
+    has_edits = serializers.SerializerMethodField()
 
     class Meta:
         model = Comment
         fields = ('id', 'article', 'author',
                   'body', 'created_at', 'updated_at',
-                  'replies', 'parent', 'likes', 'dislikes')
+                  'replies', 'parent', 'likes', 'dislikes', 'has_edits')
         read_only_fields = ('id',)
 
     @staticmethod
@@ -29,3 +30,22 @@ class CommentSerializer(serializers.ModelSerializer):
         :return: [comment:replies]
         """
         return len(CommentSerializer(obj.children(), many=True).data)
+
+    def get_has_edits(self, instance):
+        """
+        Handle checking if comment has been edited.
+        :param instance:
+        :return:
+        """
+        edit_count = instance.history.count()
+
+        return True if edit_count > 1 else False
+
+
+class EditHistorySerializer(serializers.ModelSerializer):
+    body = serializers.CharField(max_length=250, required=True)
+
+    class Meta:
+        model = Comment
+        fields = ('id', 'body', 'created_at', 'updated_at')
+        read_only_fields = ('id',)

--- a/authors/apps/comments/tests/test_comment_edit_history.py
+++ b/authors/apps/comments/tests/test_comment_edit_history.py
@@ -1,0 +1,126 @@
+from django.test import TestCase
+from django.urls import reverse
+from rest_framework.test import APIClient
+from rest_framework import status
+from authors.apps.articles.models import Articles
+from authors.apps.authentication.models import User
+from authors.apps.comments.models import Comment
+
+
+class TestCommentEdit(TestCase):
+
+    def setUp(self):
+        self.author = User.objects.create_user(
+            "tess",
+            "tess@email.com",
+            "sTr0ng%weR"
+        )
+        self.author.is_verified = True
+
+        self.reader = User.objects.create_user(
+            "reader",
+            "reader@email.com",
+            "sTr0ng%weR"
+        )
+
+        self.reader.is_verified = True
+
+        self.article = Articles.objects.create(
+            author=self.author,
+            title="The haves and the have nots",
+            body="the quick brown fox jumped over the lazy dog"
+        )
+
+        self.headers = {'HTTP_AUTHORIZATION': f'Bearer {self.reader.token}'}
+
+        self.client = APIClient()
+
+    def test_creating_comment_creates_history_record(self):
+        # setup
+        # act
+        self.comment = Comment.objects.create(
+            article=self.article,
+            author=self.reader,
+            body="I don't like this article"
+        )
+
+        # assert
+        self.assertEqual(self.comment.history.count(), 1)
+
+    def test_updating_comment_creates_associated_history_record(self):
+        # setup
+        # act
+        comment = Comment.objects.create(
+            article=self.article,
+            author=self.reader,
+            body="I don't like this article"
+        )
+
+        comment_body = "this is an updated comment body"
+        comment.body = comment_body
+        comment.save()
+
+        # assert
+        self.assertEqual(comment.history.count(), 2)
+        self.assertEqual(comment.history.most_recent().body, comment_body)
+        self.assertEqual(comment.history.earliest().body, "I don't like this article")
+
+    def test_fetch_comments_returns_edit_information(self):
+        # setup
+        # create some articles and comments on them
+        comment = Comment.objects.create(
+            article=self.article,
+            author=self.reader,
+            body="I don't like this article"
+        )
+
+        # update comment
+        comment.body = "this is an update"
+        comment.save()
+
+        # act
+        # make api call to fetch some comments
+        response = self.client.get(
+            reverse("comments:list_comment", args=[self.article.slug, comment.id]))
+
+        data = response.data
+
+        # assert
+        # that edited comments come back with edit history
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue(data['has_edits'])
+
+    def test_fetch_comment_edits(self):
+        # setup
+        # create some articles and comments on them
+        comment = Comment.objects.create(
+            article=self.article,
+            author=self.reader,
+            body="I don't like this article"
+        )
+
+        # update comment
+        comment.body = "this is an update"
+        comment.save()
+
+        # act
+        # make api call to fetch some comments
+        response = self.client.get(
+            reverse("comments:comment_history", args=[comment.id]), **self.headers)
+
+        data = response.data
+
+        # assert
+        # that edited comments come back with edit history
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(data), 2)
+
+    def test_fetching_nonexistent_comment_raises_exception(self):
+        # setup
+        # make api call to fetch some comments
+        response = self.client.get(
+            reverse("comments:comment_history", args=[32]), **self.headers)
+
+        data = response.data
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/authors/apps/comments/tests/test_comment_view.py
+++ b/authors/apps/comments/tests/test_comment_view.py
@@ -169,7 +169,6 @@ class PrivateCommentApiTest(TestCase):
         url = specific_articles_url(slug=comment.data['article'])
         self.payload.get('comment')['parent'] = comment.data['id']
         res = self.client.post(url, self.payload, **self.headers, format='json')
-
         self.assertEqual(res.status_code, status.HTTP_201_CREATED)
 
     def test_reply_to_comment_invalid_article(self):

--- a/authors/apps/comments/urls.py
+++ b/authors/apps/comments/urls.py
@@ -4,6 +4,8 @@ from authors.apps.comments.views import RetrieveCommentAPIView, RetrieveUpdateDe
 from authors.apps.articles.models import LikeDislike
 from authors.apps.articles.views import LikesView
 from .models import Comment
+from authors.apps.comments.views import RetrieveCommentAPIView, RetrieveUpdateDeleteCommentAPIView, \
+    RetrieveCommentEditHistory
 
 app_name = 'comments'
 
@@ -11,5 +13,6 @@ urlpatterns = [
     path('articles/<slug:slug>/comments/', RetrieveCommentAPIView.as_view(), name='comments'),
     path('articles/<slug:slug>/comments/<int:id>/', RetrieveUpdateDeleteCommentAPIView.as_view(), name='list_comment'),
     path('articles/comments/<int:id>/like/', LikesView.as_view(model=Comment, vote_type=LikeDislike.LIKE), name='comment_like'),
-    path('articles/comments/<int:id>/dislike/', LikesView.as_view(model=Comment, vote_type=LikeDislike.DISLIKE), name='comment_dislike')
+    path('articles/comments/<int:id>/dislike/', LikesView.as_view(model=Comment, vote_type=LikeDislike.DISLIKE), name='comment_dislike'),
+    path('comments/<int:id>/history', RetrieveCommentEditHistory.as_view(), name='comment_history')
 ]

--- a/authors/settings.py
+++ b/authors/settings.py
@@ -46,6 +46,7 @@ INSTALLED_APPS = [
     'notifications',
     'taggit',
     'taggit_serializer',
+    'simple_history',
 
     'authors.apps.authentication.apps.AuthenticationConfig',
     'authors.apps.core',
@@ -66,7 +67,7 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-
+    'simple_history.middleware.HistoryRequestMiddleware',
     'social_django.middleware.SocialAuthExceptionMiddleware',
 ]
 


### PR DESCRIPTION
#### Description
Currently, users have no way of telling whether a comment has been edited. This feature adds a new property to comments to indicate whether they have been edited or not. Also, it enables the comment author to view their edit history.

#### Type of change
- [ ] Bug fix (nonbreaking change which fixes an issue)
- [x] New feature (nonbreaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### How Has This Been Tested?
Please describe the tests that you ran to verify your changes
- [x] End to end
- [x] Integration

This feature adds the following API endpoint:

`/api/comments/{comment_id}/history` 

which returns the edit history with the following JSON structure

```json
{
    "comments": [
        {
            "id": 1,
            "body": "His name was my name three.",
            "created_at": "2019-04-23T10:00:49.830913Z",
            "updated_at": "2019-04-23T10:04:51.696038Z"
        },
        {
            "id": 1,
            "body": "brathe",
            "created_at": "2019-04-23T10:00:49.830913Z",
            "updated_at": "2019-04-23T10:00:49.830942Z"
        }
    ],
    "commentsCount": 2
}
```

PS: Only the author of a comment can view edit history. Everyone else only has the property
`has_edits` to show whether the comment has been edited or not.

```json
{
    "comments": [
        {
            "id": 1,
            "article": "the-3-musketeers",
            "author": "vino",
            "body": "His name was my name three.",
            "created_at": "2019-04-23T10:00:49.830913Z",
            "updated_at": "2019-04-23T10:04:51.696038Z",
            "replies": 0,
            "parent": null,
            "has_edits": true
        }
    ],
    "commentsCount": 1
}
```

#### Checklist:
- [x] My code follows the style guide for this project
- [ ] I have linted my code prior to submission
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

#### Pivotal Tracker
[164829224](https://www.pivotaltracker.com/story/show/164829224)