### PR TITLE
#164829198 Document API using swagger

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -56,7 +56,8 @@ whitenoise = "==4.1.2"
 django-taggit = "==1.1.0"
 django-taggit-serializer = "==0.1.7"
 django-filter = "==2.1.0"
-django-simple-history = "*"
+django-simple-history = "==2.7.2"
+drf-yasg = "==1.15.0"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "37a1131672e5d94260d65136e6eddf6832591943a88b7716ab933b569c029ae2"
+            "sha256": "3e7e8cbef88424151bcfb228964d65af501e34ac1aa6b6116ab0a34b07ea94fa"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -230,6 +230,14 @@
             "index": "pypi",
             "version": "==0.6.2"
         },
+        "drf-yasg": {
+            "hashes": [
+                "sha256:2c03c569cd1f1711e30efe3a1a56998cf61aa224cb2991e9fdac22aa47fd41e5",
+                "sha256:dfb96eb36b259c2e0da67515319a25e49f6bdd3a275412f34221cc5236d2b62a"
+            ],
+            "index": "pypi",
+            "version": "==1.15.0"
+        },
         "gunicorn": {
             "hashes": [
                 "sha256:aa8e0b40b4157b36a5df5e599f45c9c76d6af43845ba3b3b0efe2c70473c2471",
@@ -245,6 +253,12 @@
             ],
             "index": "pypi",
             "version": "==2.8"
+        },
+        "inflection": {
+            "hashes": [
+                "sha256:18ea7fb7a7d152853386523def08736aa8c32636b047ade55f7578c4edeb16ca"
+            ],
+            "version": "==0.3.1"
         },
         "itypes": {
             "hashes": [
@@ -476,6 +490,33 @@
             ],
             "index": "pypi",
             "version": "==1.2.0"
+        },
+        "ruamel.yaml": {
+            "hashes": [
+                "sha256:0939bcb399ad037ef903d74ccf2f8a074f06683bc89133ad19305067d34487c8",
+                "sha256:119cb8997d65e610de0bfd39b7f89ddfc670c43a5dbec3049b85c7457a027cac",
+                "sha256:18c0043e32a5f39c60a915015c553f90b367d34ef1b89a3a1e77baa00afec2eb",
+                "sha256:18c9ec539f8d5a07f5bdc15e41fe13c89d420d3136bbba53a36491c4d544345e",
+                "sha256:1f1ba73e1d3f1ea74ba687800fd55c3970ea2eff360a3529cb599db41af6ae5a",
+                "sha256:226f2f42770b8a50009ac0a386b158f24e642f487c981794aed59fdb5cfd232b",
+                "sha256:2ac8f8cab59c1e0ae7fa952a0e62e6e1b61cd6bef25a542b2ef923e38cc5819c",
+                "sha256:2b344ab595fe7ed7480b647cd6e6588580f147a62fbfe00fbf72e292f543390d",
+                "sha256:34e09b287d2ef5227b7a1ebaa2daa7ef9ff662542046c25b9c65c240e0ce3f8d",
+                "sha256:367e659ea250faa91a8d0a9388e5f3432f5edbbeabe68701daad7fc55a96473a",
+                "sha256:4b17efa00c14ad76a8bbfe2e31803227709f5908f15a1bd7c7b7003218a9d2e3",
+                "sha256:4fa15adfd665bc796bfa76b0b3157a28ecf28545bcf36a044ddb8dbb36e9c208",
+                "sha256:5651db922d10f51a69f4248aaf748dbf06099a6d03e1c3ab793eea6bee827d28",
+                "sha256:737ad466ac9de17f08d67b0b2d543312726b9ee8fb2172e61922642772fb3bff",
+                "sha256:786efe76c1092d392f3b1620c2585b3e09bd6a15ed82262a0b003aac58389034",
+                "sha256:79a1056a289576004a453069d3f716533629497f86fd816090dee0fd2b334b35",
+                "sha256:88f771085e5f91f641af211fe41d5052a67d388adc43a6deb26d535e40cf1c78",
+                "sha256:8bf6afc48c79597c58b0d01ce3bbf3769cb92f4c9bd4a903510afe574309ea4a",
+                "sha256:e5f929b21c90cac257fd7e3d059a5a469a712408d66bb0502159c1fe41ab27ea",
+                "sha256:eaa73a72adbba81f38147c5bebd34c0fed1813ce7cbaea60529b4c3db58ebff4",
+                "sha256:eff4f9bfcb428900d93e084808e61a8b4faf8b2bdd8695bec629364e4a7dfe31",
+                "sha256:fe64f1813251799665b15ca372b9bd1c10651fd5ceab9898caf65a3eeb6c1575"
+            ],
+            "version": "==0.15.94"
         },
         "six": {
             "hashes": [

--- a/authors/apps/analytics/views.py
+++ b/authors/apps/analytics/views.py
@@ -2,6 +2,7 @@ from rest_framework import status
 from rest_framework.permissions import (IsAuthenticated, )
 from rest_framework.response import Response
 from rest_framework.views import APIView
+from drf_yasg.utils import swagger_auto_schema
 
 from authors.apps.analytics.models import ReadsReport
 from authors.apps.analytics.renderers import AnalyticsJSONRenderer
@@ -71,6 +72,9 @@ class AnalyticsUpdateReportAPIView(APIView):
     serializer_class = ReportAPISerializer
     renderer_classes = (AnalyticsJSONRenderer,)
 
+    @swagger_auto_schema(request_body=ReportAPISerializer,
+                         responses={
+                             201: ReportAPISerializer()})
     def patch(self, request, slug):
         """
         Handles updating report if author is same as the requester and article is similar

--- a/authors/apps/articles/views.py
+++ b/authors/apps/articles/views.py
@@ -1,50 +1,41 @@
 from django.contrib.contenttypes.models import ContentType
+from drf_yasg.utils import swagger_auto_schema
 from rest_framework import (generics,
-                            status,
-                            )
+                            status, )
 from rest_framework.generics import (RetrieveUpdateAPIView,
-                                     ListAPIView,
-                                     )
+                                     ListAPIView, )
 from rest_framework.pagination import LimitOffsetPagination
 from rest_framework.permissions import (IsAuthenticatedOrReadOnly,
-                                        IsAuthenticated,
-                                        )
+                                        IsAuthenticated, )
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from authors.apps.articles.exceptions import (ArticleNotFound,
                                               RatingNotFound,
                                               ReportNotFound,
-                                              CommentNotFound,
-                                              )
+                                              CommentNotFound, )
 from authors.apps.articles.models import (Articles,
                                           Favorite,
                                           Ratings,
-                                          ReportArticles,
-                                          )
+                                          ReportArticles, )
 from authors.apps.articles.permissions import (IsOwnerOrReadOnly,
-                                               IsVerified,
-                                               )
+                                               IsVerified, )
 from authors.apps.articles.renderers import (ArticleJSONRenderer,
                                              RatingJSONRenderer,
-                                             ReportJSONRenderer,
-                                             )
+                                             ReportJSONRenderer, )
 from authors.apps.articles.response_messages import ERROR_MESSAGES
 from authors.apps.articles.serializers import (ArticleSerializer,
                                                RatingsSerializer,
-                                               ReportsSerializer,
-                                               )
+                                               ReportsSerializer, )
 from authors.apps.authentication.models import User
 from authors.apps.authentication.permissions import IsVerifiedUser
 from authors.apps.authentication.serializers import UserSerializer
-from authors.apps.core.utils import send_notifications
-from authors.apps.highlights.utils import remove_highlights_for_article
-from authors.apps.authentication.serializers import UserSerializer
 from authors.apps.comments.models import Comment
-from authors.apps.core.reports import reporting
 from authors.apps.core.utils import send_notifications
 from .models import LikeDislike
 from .serializers import FavoriteSerializer
+from authors.apps.core.reports import reporting
+from authors.apps.highlights.utils import remove_highlights_for_article
 
 
 class CreateArticlesAPIView(APIView):
@@ -57,6 +48,7 @@ class CreateArticlesAPIView(APIView):
     renderer_classes = (ArticleJSONRenderer,)
     pagination_class = LimitOffsetPagination
 
+
     def get(self, request, format=None):
         articles = Articles.objects.all()
         paginator = self.pagination_class()
@@ -64,6 +56,9 @@ class CreateArticlesAPIView(APIView):
         serializer = self.serializer_class(page, many=True, context={'request': request})
         return paginator.get_paginated_response(serializer.data)
 
+    @swagger_auto_schema(request_body=ArticleSerializer,
+                         responses={
+                             201: ArticleSerializer()})
     def post(self, request):
         article = request.data.get('article', {})
         serializer = self.serializer_class(data=article)
@@ -119,6 +114,9 @@ class RetrieveUpdateDeleteArticleAPIView(RetrieveUpdateAPIView):
 
         return Response(serializer.data, status=status.HTTP_200_OK)
 
+    @swagger_auto_schema(request_body=ArticleSerializer,
+                         responses={
+                             200: ArticleSerializer()})
     def put(self, request, slug, format=None):
         article = self.get_object(slug)
         self.check_object_permissions(request, article)
@@ -189,6 +187,9 @@ class CreateListRatingsAPIView(APIView):
             return Response({'data': filtered_ratings, 'RatingsCount': len(serializer.data)}, status=status.HTTP_200_OK)
         return Response({'errors': 'no ratings for this article present'}, status=status.HTTP_404_NOT_FOUND)
 
+    @swagger_auto_schema(request_body=RatingsSerializer,
+                         responses={
+                             201: RatingsSerializer()})
     def post(self, request, slug):
         """
         Method to post a rating of a particular article
@@ -276,6 +277,9 @@ class RetrieveUpdateDeleteRatingAPIView(APIView):
         serializer = RatingsSerializer(rating)
         return Response(serializer.data, status=status.HTTP_200_OK)
 
+    @swagger_auto_schema(request_body=RatingsSerializer,
+                         responses={
+                             200: RatingsSerializer()})
     def put(self, request, pk, format=None):
         """
         Method to edit a specific rating
@@ -385,6 +389,9 @@ class FavoriteView(generics.CreateAPIView):
     permission_classes = (IsAuthenticatedOrReadOnly,)
     serializer_class = FavoriteSerializer
 
+    @swagger_auto_schema(request_body=FavoriteSerializer,
+                         responses={
+                             201: FavoriteSerializer()})
     def post(self, request, slug):
         """Creates a favorite"""
         data = request.data
@@ -526,6 +533,9 @@ class CreateListReportsAPIView(APIView):
         except Articles.DoesNotExist:
             raise ArticleNotFound
 
+    @swagger_auto_schema(request_body=ReportsSerializer,
+                         responses={
+                             201: ReportsSerializer()})
     def post(self, request, slug):
         """
         Method to post a report of a particular article
@@ -626,6 +636,9 @@ class RetrieveUpdateDeleteReportAPIView(APIView):
         serializer = ReportsSerializer(report)
         return Response(serializer.data, status=status.HTTP_200_OK)
 
+    @swagger_auto_schema(request_body=ReportsSerializer,
+                         responses={
+                             200: ReportsSerializer()})
     def put(self, request, pk, format=None):
         """
         Method to edit a specific report

--- a/authors/apps/authentication/views.py
+++ b/authors/apps/authentication/views.py
@@ -3,27 +3,27 @@ from django.conf import settings
 from django.core.mail import EmailMultiAlternatives
 from django.template.loader import render_to_string
 from django.urls import reverse
-from django.utils.encoding import force_bytes, force_text
-from django.utils.http import urlsafe_base64_encode, urlsafe_base64_decode
+from django.utils.encoding import (force_bytes,
+                                   force_text, )
+from django.utils.http import (urlsafe_base64_encode,
+                               urlsafe_base64_decode, )
+from drf_yasg.utils import swagger_auto_schema
 from rest_framework import status
-from rest_framework.generics import RetrieveUpdateAPIView, CreateAPIView
-from rest_framework.permissions import AllowAny, IsAuthenticated
+from rest_framework.generics import (RetrieveUpdateAPIView,
+                                     CreateAPIView, )
+from rest_framework.permissions import (AllowAny,
+                                        IsAuthenticated, )
 from rest_framework.response import Response
 from rest_framework.views import APIView
-from django.core.mail import EmailMultiAlternatives
-from django.template.loader import render_to_string
-from django.utils.encoding import force_bytes, force_text
-from django.utils.http import urlsafe_base64_encode, urlsafe_base64_decode
-from django.urls import reverse
-
-from social_django.utils import load_backend, load_strategy
-
-from social_core.backends.oauth import BaseOAuth1, BaseOAuth2
+from social_core.backends.oauth import (BaseOAuth1,
+                                        BaseOAuth2, )
 from social_core.exceptions import MissingBackend
-from social_django.utils import load_backend, load_strategy
+from social_django.utils import (load_backend,
+                                 load_strategy, )
 
 from .backends import email_activation_token
-from .models import User, PasswordReset
+from .models import (User,
+                     PasswordReset, )
 from .renderers import UserJSONRenderer
 from .response_messages import PASSWORD_RESET_MSGS
 from .serializers import (
@@ -34,11 +34,10 @@ from .serializers import (
     PasswordResetSerializer,
     PasswordResetRequestSerializer,
     SetNewPasswordSerializer,
-    NotificationSerializer, UserNotificationSerializer)
-from django.conf import settings
-import jwt
-from .utils import PasswordResetTokenHandler
-from .utils import validate_image
+    NotificationSerializer,
+    UserNotificationSerializer, )
+from .utils import (PasswordResetTokenHandler,
+                    validate_image, )
 
 
 class RegistrationAPIView(APIView):
@@ -47,6 +46,9 @@ class RegistrationAPIView(APIView):
     renderer_classes = (UserJSONRenderer,)
     serializer_class = RegistrationSerializer
 
+    @swagger_auto_schema(request_body=RegistrationSerializer,
+                         responses={
+                             201: UserSerializer()})
     def post(self, request):
         user = request.data.get('user', {})
 
@@ -108,6 +110,9 @@ class LoginAPIView(APIView):
     renderer_classes = (UserJSONRenderer,)
     serializer_class = LoginSerializer
 
+    @swagger_auto_schema(request_body=LoginSerializer,
+                         responses={
+                             200: UserSerializer()})
     def post(self, request):
         user = request.data.get('user', {})
 
@@ -138,6 +143,9 @@ class UserRetrieveUpdateAPIView(RetrieveUpdateAPIView):
 
         return Response(serializer.data, status=status.HTTP_200_OK)
 
+    @swagger_auto_schema(query_serializer=RegistrationSerializer,
+                         responses={
+                             200: UserSerializer()})
     def update(self, request, *args, **kwargs):
         # serializer_data = request.data.get('user', {})
 
@@ -190,6 +198,9 @@ class SocialOAuthAPIView(CreateAPIView):
     renderer_classes = (UserJSONRenderer,)
     serializer_class = SocialOAuthSerializer
 
+    @swagger_auto_schema(query_serializer=SocialOAuthSerializer,
+                         responses={
+                             200: UserSerializer()})
     def create(self, request, *args, **kwargs):
         """
         Overide 'create' instead of 'perform-create' to access request
@@ -261,6 +272,9 @@ class PasswordResetAPIView(APIView):
 
     permission_classes = (AllowAny,)
 
+    @swagger_auto_schema(request_body=PasswordResetRequestSerializer,
+                         responses={
+                             200: PasswordResetRequestSerializer()})
     def post(self, request):
         """ 
         Create a password reset link and send it to the user who requested it.
@@ -336,6 +350,9 @@ class SetPasswordAPIView(APIView):
     """
     permission_classes = (AllowAny,)
 
+    @swagger_auto_schema(request_body=SetNewPasswordSerializer,
+                         responses={
+                             200: SetNewPasswordSerializer()})
     def patch(self, request, reset_token):
         """
         Create a password reset link and send it to the user who requested it.
@@ -449,6 +466,9 @@ class NotificationsView(APIView):
 
         return Response(notifications.data)
 
+    @swagger_auto_schema(query_serializer=NotificationSerializer,
+                         responses={
+                             200: NotificationSerializer()})
     def patch(self, request):
         request.user.notifications.update(is_read=True)
 
@@ -473,6 +493,9 @@ class NotificationSettingsView(APIView):
 
         return Response(notification_settings)
 
+    @swagger_auto_schema(query_serializer=UserNotificationSerializer,
+                         responses={
+                             200: UserNotificationSerializer()})
     def patch(self, request):
         notification_settings = request.user.notification_settings
         serializer = UserNotificationSerializer(notification_settings, data=request.data)

--- a/authors/apps/bookmarks/views.py
+++ b/authors/apps/bookmarks/views.py
@@ -1,3 +1,4 @@
+from drf_yasg.utils import swagger_auto_schema
 from rest_framework import status
 from rest_framework.permissions import (
     IsAuthenticated)
@@ -19,6 +20,9 @@ class GetBookmarkListAPIView(APIView):
     permission_classes = (IsAuthenticated, IsVerifiedUser,)
     serializer_class = BookmarkSerializer
 
+    @swagger_auto_schema(query_serializer=BookmarkSerializer,
+                         responses={
+                             200: BookmarkSerializer()})
     def get(self, request):
         """
         Return a current user's bookmarked articles.
@@ -87,6 +91,9 @@ class DeleteBookmarkAPIView(APIView):
         except Bookmark.DoesNotExist:
             return None
 
+    @swagger_auto_schema(query_serializer=BookmarkSerializer,
+                         responses={
+                             200: BookmarkSerializer()})
     def delete(self, request, pk, format=None):
         """
         Method to delete a specific booking
@@ -132,6 +139,9 @@ class CreateBookmarkAPIView(APIView):
     permission_classes = (IsAuthenticated, IsVerifiedUser, IsOwner)
     serializer_class = BookmarkSerializer
 
+    @swagger_auto_schema(query_serializer=BookmarkSerializer,
+                         responses={
+                             200: BookmarkSerializer()})
     def post(self, request, slug):
         """
         Create a bookmark for an article

--- a/authors/apps/comments/views.py
+++ b/authors/apps/comments/views.py
@@ -1,9 +1,11 @@
+from drf_yasg.utils import swagger_auto_schema
 from rest_framework import status
 from rest_framework.permissions import IsAuthenticatedOrReadOnly, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from authors.apps.articles.models import Articles, Favorite
+from authors.apps.articles.models import (Articles,
+                                          Favorite, )
 from authors.apps.articles.permissions import IsOwnerOrReadOnly
 from authors.apps.authentication.permissions import IsVerifiedUser
 from authors.apps.comments.models import Comment
@@ -22,6 +24,9 @@ class RetrieveCommentAPIView(APIView):
     serializer_class = CommentSerializer
     renderer_classes = (CommentJSONRenderer,)
 
+    # @swagger_auto_schema(request_body=CommentSerializer,
+    #                      responses={
+    #                          200: CommentSerializer()})
     def get(self, request, slug):
         """
         Handles listing all comments on an article
@@ -40,6 +45,9 @@ class RetrieveCommentAPIView(APIView):
         except Articles.DoesNotExist:
             return Response({"errors": COMMENTS_MSG['ARTICLE_DOES_NOT_EXIST']}, status=status.HTTP_404_NOT_FOUND)
 
+    @swagger_auto_schema(request_body=CommentSerializer,
+                         responses={
+                             200: CommentSerializer()})
     def post(self, request, slug):
         """
         Handles creating a new comment on an article
@@ -99,6 +107,9 @@ class RetrieveUpdateDeleteCommentAPIView(APIView):
         except Comment.DoesNotExist:
             return Response({"errors": COMMENTS_MSG['COMMENT_DOES_NOT_EXIST']}, status=status.HTTP_404_NOT_FOUND)
 
+    @swagger_auto_schema(request_body=CommentSerializer,
+                         responses={
+                             200: CommentSerializer()})
     def patch(self, request, *args, **kwargs):
         """
         Handles updating a comment if author is same as the requester

--- a/authors/apps/highlights/views.py
+++ b/authors/apps/highlights/views.py
@@ -3,6 +3,7 @@ from rest_framework.permissions import (
     IsAuthenticated)
 from rest_framework.response import Response
 from rest_framework.views import APIView
+from drf_yasg.utils import swagger_auto_schema
 
 from authors.apps.articles.models import Articles
 from authors.apps.authentication.permissions import IsVerifiedUser
@@ -68,6 +69,9 @@ class CreateGetDeleteMyHighlightsAPIView(APIView):
         },
             status=status.HTTP_200_OK)
 
+    @swagger_auto_schema(request_body=HighlightSerializer,
+                         responses={
+                             201: HighlightSerializer()})
     def post(self, request, slug):
         """
         Create a highlight for an article
@@ -172,6 +176,9 @@ class UpdateMyHighlightsAPIView(APIView):
     permission_classes = (IsAuthenticated, IsVerifiedUser, IsOwner)
     serializer_class = HighlightSerializer
 
+    @swagger_auto_schema(request_body=HighlightSerializer,
+                         responses={
+                             201: HighlightSerializer()})
     def patch(self, request, pk):
         """
         Edits a highlight's comment for an article highlight

--- a/authors/apps/search/views.py
+++ b/authors/apps/search/views.py
@@ -29,6 +29,9 @@ class SearchArticleListAPIView(generics.ListAPIView):
     filterset_class = ArticleFilter
     search_fields = ('author__username', 'title', 'created_at',)
 
+    # @swagger_auto_schema(query_serializer=ArticleSerializer,
+    #                      responses={
+    #                          200: ArticleSerializer()})
     def get_queryset(self):
         # Getting specific properties from the request body
         favorited = self.request.query_params.get('favorited', '')  # returns username

--- a/authors/settings.py
+++ b/authors/settings.py
@@ -47,6 +47,7 @@ INSTALLED_APPS = [
     'taggit',
     'taggit_serializer',
     'simple_history',
+    'drf_yasg',
 
     'authors.apps.authentication.apps.AuthenticationConfig',
     'authors.apps.core',
@@ -244,6 +245,17 @@ CLOUDINARY = {
     'api_key': config('CLOUDINARY_API_KEY'),
     'api_secret': config('CLOUDINARY_API_SECRET'),
     'secure': True
+}
+
+SWAGGER_SETTINGS = {
+    'SECURITY_DEFINITIONS': {
+        'Bearer': {
+            'type': 'apiKey',
+            'name': 'Authorization',
+            'description': 'Token based authentication. ie Bearer token',
+            'in': 'header'
+        }
+    }
 }
 
 TESTING = len(sys.argv) > 1 and sys.argv[1] == 'test'

--- a/authors/urls.py
+++ b/authors/urls.py
@@ -13,10 +13,33 @@ Including another URLconf
     1. Import the include() function: from django.conf.urls import url, include
     2. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
 """
+from django.conf.urls import url
 from django.contrib import admin
-from django.urls import include, path
+from django.urls import (include,
+                         path, )
+from drf_yasg import openapi
+from drf_yasg.views import get_schema_view
+from rest_framework import permissions
+
+...
+
+schema_view = get_schema_view(
+    openapi.Info(
+        title="Authors Heaven API",
+        default_version='v1',
+        description="A social platform for the creative at heart.",
+        terms_of_service="https://www.google.com/policies/terms/",
+        contact=openapi.Contact(email="contact@authorsheaven.com"),
+        license=openapi.License(name="BSD License"),
+    ),
+    public=True,
+    permission_classes=(permissions.AllowAny,),
+)
 
 urlpatterns = [
+    url(r'^swagger(?P<format>\.json|\.yaml)$', schema_view.without_ui(cache_timeout=0), name='schema-json'),
+    url(r'^swagger/$', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
+    url(r'^redoc/$', schema_view.with_ui('redoc', cache_timeout=0), name='schema-redoc'),
     path('admin/', admin.site.urls),
     path('api/', include('authors.apps.authentication.urls', namespace='authentication')),
     path('api/', include('authors.apps.profiles.urls', namespace='profiles')),

--- a/release.sh
+++ b/release.sh
@@ -3,6 +3,6 @@ echo "Running Release Tasks"
 
 echo "Running Database migrations and migrating the new changes"
 python manage.py makemigrations authentication profiles articles comments bookmarks analytics highlights
-python manage.py migrate
+python manage.py migrate --noinput
 
 echo "Done.."


### PR DESCRIPTION
#### Description
Users should be able to view Document API using swagger or redoc
#### Type of change
- [ ] Bug fix (nonbreaking change which fixes an issue)
- [x] New feature (nonbreaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### How Has This Been Tested?
Please describe the tests that you ran to verify your changes
- [x] End to end
- [ ] Integration

### How can this be manually tested?
1.  Clone the repository 
```https://github.com/andela/ah-centauri-backend.git```

2. cd into project directory and checkout into this branch
```bash 
cd ah-centauri-backend
git checkout feature/164829198-api-documentation-using-swagger
```

3. Rename the .env.example file into .env and update the parameters with your own keys.

4. Start development server and send the following through postman

The feature has two endpoints, i.e.
 - `GET` view swagger UI doc - `/swagger/`
 - `GET` view redoc UI doc - `/redoc/`

#### Checklist:
- [x] My code follows the style guide for this project
- [x] I have linted my code prior to submission
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

#### Pivotal Tracker
[Delivers #164829198]

Signed-off-by: Valerie Chepng'eno Rono <ronovalerie@gmail.com>
Signed-off-by: bl4ck4ndbr0wn <alphandirangu@gmail.com>