### PR TITLE
bug(article-views)-fix-total-views-bug

### DIFF
--- a/authors/apps/analytics/models.py
+++ b/authors/apps/analytics/models.py
@@ -11,7 +11,7 @@ class ReadsReport(TimeStampModel):
     Display no of users who clicked on an article.
     """
     article = models.ForeignKey(Articles, on_delete=models.CASCADE)
-    user = models.ForeignKey(User, on_delete=models.CASCADE)
+    user = models.ForeignKey(User, on_delete=models.CASCADE, null=True)
     # Shows if user has read the entire article.
     full_read = models.BooleanField(default=False)
 
@@ -20,8 +20,14 @@ class ReadsReport(TimeStampModel):
         ReadReport String representation
         :return:
         """
-        return f'{self.article.slug} viewed by {self.user.username}: ' \
-            f'read entire article == {self.full_read}'
+        if self.user:
+            return f'{self.article.slug} viewed by {self.user.username}: ' \
+                f'read entire article == {self.full_read}'
+        else:
+            return f'{self.article.slug} viewed by Anonymous: ' \
+                f'read entire article == {self.full_read}'
+
 
     class Meta:
         ordering = ['created_at']
+        unique_together = (('user', 'article'),)

--- a/authors/apps/analytics/tests/test_analitics_model.py
+++ b/authors/apps/analytics/tests/test_analitics_model.py
@@ -11,7 +11,7 @@ class TestAnalyticsModel(BaseAnalyticsSetup):
         """
         Test if we can create a report using the report model class
         """
-        report = ReadsReport.objects.create(user=self.author, article=self.article)
+        report = ReadsReport.objects.create(user=self.author, article=self.article, num_views=0)
 
         self.assertEqual(report.article, self.article)
 
@@ -19,9 +19,20 @@ class TestAnalyticsModel(BaseAnalyticsSetup):
         """
         Test if the string of the report model returns the expected string
         """
-        report = ReadsReport.objects.create(user=self.author, article=self.article)
+        report = ReadsReport.objects.create(user=self.author, article=self.article, num_views=0)
 
         rep = f'{report.article.slug} viewed by {report.user.username}: ' \
+            f'read entire article == {report.full_read}'
+
+        self.assertIn(str(rep), str(report))
+
+    def test_report_model_string_representation_anonymous_user(self):
+        """
+        Test if the string of the report model returns the expected string
+        """
+        report = ReadsReport.objects.create(article=self.article, num_views=0)
+
+        rep = f'{report.article.slug} viewed by Anonymous: ' \
             f'read entire article == {report.full_read}'
 
         self.assertIn(str(rep), str(report))

--- a/authors/apps/articles/views.py
+++ b/authors/apps/articles/views.py
@@ -35,6 +35,7 @@ from authors.apps.articles.serializers import (ArticleSerializer,
                                                ReportsSerializer,
                                                )
 from authors.apps.authentication.models import User
+from authors.apps.analytics.models import ReadsReport
 from authors.apps.authentication.permissions import IsVerifiedUser
 from authors.apps.authentication.serializers import UserSerializer
 from authors.apps.core.utils import send_notifications
@@ -113,9 +114,14 @@ class RetrieveUpdateDeleteArticleAPIView(RetrieveUpdateAPIView):
         article = self.get_object(slug)
         serializer = ArticleSerializer(article, context={'request': request})
 
-        # Reporting the reading starts of an article
+        # Reporting the reading stats of an article
         if request.user.is_authenticated:
-            reporting(user=request.user, article=article)
+            try:
+                ReadsReport.objects.get(user=request.user, article=article)
+            except ReadsReport.DoesNotExist:
+                reporting(user=request.user, article=article)
+        else:
+            reporting(article=article)
 
         return Response(serializer.data, status=status.HTTP_200_OK)
 

--- a/authors/apps/core/reports.py
+++ b/authors/apps/core/reports.py
@@ -8,9 +8,5 @@ def reporting(*args, **kwargs):
     :param kwargs:
     :return: [report]
     """
-    try:
-        report = ReadsReport.objects.get(user=kwargs.get('user'), article=kwargs.get('article'))
-    except ReadsReport.DoesNotExist:
-        report = ReadsReport.objects.create(user=kwargs.get('user'), article=kwargs.get('article'))
-
+    report = ReadsReport.objects.create(**kwargs)
     return report


### PR DESCRIPTION
#### Description
When a user is authenticated and verified, he/she should be able to view the number of visitors(authenticated or not) who viewed a specific article

#### Type of change
- [x] Bug fix (nonbreaking change which fixes an issue)
- [ ] New feature (nonbreaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### How Has This Been Tested?
Please describe the tests that you ran to verify your changes
- [x] End to end
- [x] Integration

### How can this be manually tested?
1.  Clone the repository 
```https://github.com/andela/ah-centauri-backend.git```

2. cd into project directory and checkout into this branch
```bash 
cd ah-centauri-backend
git checkout bug/165677904-fix-total-number-of-article-viewers
```

3. Rename the .env.example file into .env and update the parameters with your own keys.

4. Start development server and send the following through postman

The feature has one endpoint, i.e.
 - `GET` get stats on articles i have authored - `/api/analytics/me`

#### Checklist:
- [x] My code follows the style guide for this project
- [ ] I have linted my code prior to submission
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

#### Pivotal Tracker
-ensure proper number of views on an article is returned, authenticated or not

[Delivers #165677904]