### PR TITLE
#165682542 bug fix on Articles search result count

### DIFF
--- a/authors/apps/search/renderer.py
+++ b/authors/apps/search/renderer.py
@@ -13,5 +13,5 @@ class SearchJSONRenderer(JSONRenderer):
         # check for this case.
         return json.dumps({
             "articles": data,
-            'articlesCount': len(data),
+            'articlesCount': data['count'],
         })


### PR DESCRIPTION
### Steps to reproduce
1. Run the search query URL
2. enter a query params and send
3. The results gotten has the ArticlesCount as 4 on all query requests.

### Expected
Return the results count as per the results gotten.

### Actual
Returns length of data received instead of a count of the results gotten.

### Pivotal tracker
#165682542