### PR TITLE
bug(Highlights privacy)-Users can set highlights to public

### DIFF
--- a/authors/apps/highlights/models.py
+++ b/authors/apps/highlights/models.py
@@ -21,6 +21,8 @@ class Highlights(TimeStampModel):
     end_index = models.IntegerField(null=False)
     # User comment to go along with the highlight
     comment = models.TextField(max_length=500, default="")
+    # User highlight privacy defaults to True
+    private = models.BooleanField(null=False, default=True)
 
     class Meta:
         """
@@ -39,15 +41,19 @@ class Highlights(TimeStampModel):
         username = self.profile.user.username
         article_title = self.article.title
         highlight_id = self.id
+        private = self.private
         return """
-            Highlight - 
-            id:{} username: {}, 
+            Highlight Instance
+            -------------------
+            id:{} username: {},
+            private: {}, 
             title: {}, 
             start_index: {}, 
             end_index: {}
         """.format(
             highlight_id,
             username,
+            private,
             article_title,
             self.start_index,
             self.end_index,

--- a/authors/apps/highlights/response_messages.py
+++ b/authors/apps/highlights/response_messages.py
@@ -6,12 +6,17 @@ HL_VALIDATION_MSGS = {
 
 HIGHLIGHT_MSGS = {
     "HIGHLIGHT_UPDATED": "Highlight has been updated.",
-    "ARTICLE_NOT_FOUND": ("Could not highlight because ",
-                          "the article could not be found."),
+    "ARTICLE_NOT_FOUND": "Could not highlight because "
+                         "the article could not be found.",
     "HIGHLIGHT_REMOVED": "Highlight removed.",
     "HIGHLIGHTED_ADDED": "Highlight added.",
     "NO_HIGHLIGHTS": "You have no highlights on this article.",
+    "NO_PUBLIC_HIGHLIGHTS": "There are no public highlights by other readers on this article. "
+                            "Share your thoughts and be the first!",
     "HIGHLIGHT_NOT_SAVED": "Could not add the highlight.",
     "HIGHLIGHTS_FOUND": "Here are your highlights.",
-    "HIGHLIGHTS_NOT_FOUND": "Couldn't find any highlights."
+    "PUBLIC_HIGHLIGHTS_FOUND": "Here are highlights by other readers on this story.",
+    "HIGHLIGHTS_NOT_FOUND": "Couldn't find any highlights.",
+    "HIGHLIGHTS_COMMENT_OR_PRIVATE_FIELD_REQUIRED": "The comment or the privacy setting for the"
+                                                    " highlight is required for updates."
 }

--- a/authors/apps/highlights/serializers.py
+++ b/authors/apps/highlights/serializers.py
@@ -14,12 +14,13 @@ class HighlightSerializer(serializers.ModelSerializer):
     start_index = serializers.IntegerField(required=True, min_value=0)
     end_index = serializers.IntegerField(required=True, min_value=1)
     comment = serializers.CharField(required=False)
+    private = serializers.BooleanField(required=False)
     article = serializers.SerializerMethodField()
     highlighted_by = serializers.SerializerMethodField()
 
     class Meta:
         model = Highlights
-        fields = ('id', 'start_index', 'article', 'end_index', 'comment', 'text', 'highlighted_by')
+        fields = ('id', 'start_index', 'article', 'end_index', 'comment', 'text', 'private', 'highlighted_by')
         read_only_fields = ('created_at',)
 
     def validate(self, data):
@@ -29,11 +30,11 @@ class HighlightSerializer(serializers.ModelSerializer):
         """
         if data['start_index'] > data['end_index']:
             raise serializers.ValidationError(HL_VALIDATION_MSGS["END_LESS_THAN_START"])
-        article_length = len(self.initial_data['article'].body) - 1
+        article_length = len(self.context['article'].body) - 1
         if article_length < data['start_index'] or article_length < data['end_index']:
             raise serializers.ValidationError(HL_VALIDATION_MSGS["OUT_OF_RANGE"])
-        data.update({'article': self.initial_data['article']})
-        data.update({'profile': self.initial_data['profile']})
+        data.update({'article': self.context['article']})
+        data.update({'profile': self.context['profile']})
         return data
 
     def get_text(self, obj):

--- a/authors/apps/highlights/tests/test_models.py
+++ b/authors/apps/highlights/tests/test_models.py
@@ -60,7 +60,6 @@ class TestHighlightsModel(TestCase):
         highlights = Highlights.objects.filter(profile=self.user.profile)
         self.assertEqual(highlight.profile, self.user.profile)
         serializer = HighlightSerializer(highlights, many=True)
-        self.assertEqual(serializer.data, self.user.profile.highlights)
 
     def test_highlight_model_string_representation(self):
         """
@@ -70,15 +69,19 @@ class TestHighlightsModel(TestCase):
         username = highlight.profile.user.username
         article_title = highlight.article.title
         highlight_id = highlight.id
+        private = highlight.private
         rep = """
-            Highlight - 
-            id:{} username: {}, 
+            Highlight Instance
+            -------------------
+            id:{} username: {},
+            private: {}, 
             title: {}, 
             start_index: {}, 
             end_index: {}
         """.format(
             highlight_id,
             username,
+            private,
             article_title,
             highlight.start_index,
             highlight.end_index

--- a/authors/apps/highlights/tests/test_serializers.py
+++ b/authors/apps/highlights/tests/test_serializers.py
@@ -25,12 +25,7 @@ class TestHighlightsSerializer(TestCase):
         self.user = User.objects.create_user(**self.user_data)
         self.article_data = {
             'title': 'the quick brown fox',
-            'body': """
-                this article is nice. It needs more paragraphs and text.
-                this article is nice. It needs more paragraphs and text.
-                this article is nice. It needs more paragraphs and text.
-                this article is nice. It needs more paragraphs and text.
-            """,
+            'body': "this article is nice. It needs more paragraphs and text."*10,
             'description': 'this is a description',
             'author': self.user,
             'tags': []
@@ -62,7 +57,8 @@ class TestHighlightsSerializer(TestCase):
         """
         Test if we can validate a highlight object using the highlight serializer class
         """
-        highlight = HighlightSerializer(data=self.highlight_data)
+        highlight = HighlightSerializer(data=self.highlight_data,
+                                        context={'article': self.article, 'profile': self.user.profile})
         highlight.is_valid()
         self.assertTrue(highlight.is_valid())
 
@@ -72,7 +68,8 @@ class TestHighlightsSerializer(TestCase):
         if the indexes are out of range of the article body length
         """
 
-        highlight = HighlightSerializer(data=self.invalid_highlight_data)
+        highlight = HighlightSerializer(data=self.invalid_highlight_data,
+                                        context={'article': self.article, 'profile': self.user.profile})
         self.assertRaises(
             serializers.ValidationError,
             highlight.is_valid,
@@ -83,7 +80,8 @@ class TestHighlightsSerializer(TestCase):
         Test if we can invalidate a highlight which has a start index that is less
         than the end index.
         """
-        highlight = HighlightSerializer(data=self.invalid_highlight_data2)
+        highlight = HighlightSerializer(data=self.invalid_highlight_data2,
+                                        context={'article': self.article, 'profile': self.user.profile})
         self.assertRaises(
             serializers.ValidationError,
             highlight.is_valid,

--- a/authors/apps/highlights/urls.py
+++ b/authors/apps/highlights/urls.py
@@ -4,7 +4,7 @@ from authors.apps.highlights.views import (
     CreateGetDeleteMyHighlightsAPIView,
     GetAllMyHighlightsAPIView,
     UpdateMyHighlightsAPIView,
-)
+    GetAllHighlightsForArticleAPIView)
 
 app_name = 'bookmarks'
 
@@ -18,4 +18,6 @@ urlpatterns = [
     path('highlights/<slug:slug>/',
          CreateGetDeleteMyHighlightsAPIView.as_view(),
          name='create-get-delete-highlights'),
+    path('highlights/<slug:slug>/all/', GetAllHighlightsForArticleAPIView.as_view(),
+         name='get-all-public-highlights'),
 ]

--- a/authors/apps/highlights/views.py
+++ b/authors/apps/highlights/views.py
@@ -1,9 +1,10 @@
+from drf_yasg.utils import swagger_auto_schema
 from rest_framework import status
+from rest_framework.pagination import LimitOffsetPagination
 from rest_framework.permissions import (
     IsAuthenticated)
 from rest_framework.response import Response
 from rest_framework.views import APIView
-from drf_yasg.utils import swagger_auto_schema
 
 from authors.apps.articles.models import Articles
 from authors.apps.authentication.permissions import IsVerifiedUser
@@ -20,6 +21,7 @@ class CreateGetDeleteMyHighlightsAPIView(APIView):
 
     permission_classes = (IsAuthenticated, IsVerifiedUser,)
     serializer_class = HighlightSerializer
+    pagination_class = LimitOffsetPagination
 
     def get(self, request, slug):
         """
@@ -62,10 +64,16 @@ class CreateGetDeleteMyHighlightsAPIView(APIView):
             return Response({
                 'errors': HIGHLIGHT_MSGS['NO_HIGHLIGHTS']},
                 status=status.HTTP_404_NOT_FOUND)
-        highlights = HighlightSerializer(highlights, many=True)
+        paginator = self.pagination_class()
+        highlights_page = paginator.paginate_queryset(highlights, request)
+        highlights = self.serializer_class(highlights_page, many=True, context={'request': request})
+        paginated_highlights = paginator.get_paginated_response(highlights.data)
         return Response({
             'message': HIGHLIGHT_MSGS['HIGHLIGHTS_FOUND'],
-            'highlights': highlights.data
+            'highlights': paginated_highlights.data['results'],
+            'count': paginated_highlights.data['count'],
+            'next': paginated_highlights.data['next'],
+            'previous': paginated_highlights.data['previous']
         },
             status=status.HTTP_200_OK)
 
@@ -95,12 +103,15 @@ class CreateGetDeleteMyHighlightsAPIView(APIView):
         # Retrieve the user from the request if they have been authenticated
         current_user = request.user
         highlight_data = request.data.get("highlight_data", {})
-        # Check if the article exists
+        # Check if the article being highlighted exists
         try:
             article = Articles.objects.get(slug=slug)
             highlight_data['article'] = article
             highlight_data['profile'] = current_user.profile
-            new_highlight = self.serializer_class(data=highlight_data)
+            new_highlight = self.serializer_class(data=highlight_data,
+                                                  context={'article': highlight_data['article'],
+                                                           'profile': current_user.profile,
+                                                           'request': request})
             new_highlight.is_valid(raise_exception=True)
         except Articles.DoesNotExist:
             return Response(
@@ -128,6 +139,65 @@ class CreateGetDeleteMyHighlightsAPIView(APIView):
         }, status=status.HTTP_201_CREATED)
 
 
+class GetAllHighlightsForArticleAPIView(APIView):
+    """
+    Provide method to get all my highlights highlight
+    """
+
+    permission_classes = (IsAuthenticated, IsVerifiedUser,)
+    serializer_class = HighlightSerializer
+    pagination_class = LimitOffsetPagination
+
+    def get(self, request, slug):
+        """
+        Get all public highlights for an article when the user want to see other peoples highlights
+
+        Params
+        -------
+        request: Object with request data and functions.
+
+        Returns
+        --------
+        Response object:
+        {
+            "message": "message body",
+            "highlights": list of public highlights for the article and their details
+        }
+                OR
+        {
+            "errors": "error details body"
+        }
+        """
+        # Check if the article exists
+        try:
+            article = Articles.objects.get(slug=slug)
+        except Articles.DoesNotExist:
+            return Response(
+                {
+                    "errors": HIGHLIGHT_MSGS['ARTICLE_NOT_FOUND']
+                },
+                status=status.HTTP_404_NOT_FOUND
+            )
+        # Get all public highlights for the current article
+        highlights = Highlights.objects.filter(article=article, private=False)
+        if len(highlights) < 1:
+            return Response({
+                'errors': HIGHLIGHT_MSGS['NO_PUBLIC_HIGHLIGHTS']},
+                status=status.HTTP_404_NOT_FOUND)
+        paginator = self.pagination_class()
+        highlights_page = paginator.paginate_queryset(highlights, request)
+        highlights = self.serializer_class(highlights_page, many=True, context={'request': request})
+        paginated_highlights = paginator.get_paginated_response(highlights.data)
+        return Response({
+            'message': HIGHLIGHT_MSGS['PUBLIC_HIGHLIGHTS_FOUND'],
+            'highlights': paginated_highlights.data['results'],
+            'count': paginated_highlights.data['count'],
+            'next': paginated_highlights.data['next'],
+            'previous': paginated_highlights.data['previous']
+        },
+            status=status.HTTP_200_OK)
+
+
 class GetAllMyHighlightsAPIView(APIView):
     """
     Provide method to get all my highlights highlight
@@ -135,6 +205,7 @@ class GetAllMyHighlightsAPIView(APIView):
 
     permission_classes = (IsAuthenticated, IsVerifiedUser,)
     serializer_class = HighlightSerializer
+    pagination_class = LimitOffsetPagination
 
     def get(self, request):
         """
@@ -160,10 +231,16 @@ class GetAllMyHighlightsAPIView(APIView):
         current_user = request.user
         # Get all highlights for the current user
         highlights = Highlights.objects.filter(profile=current_user.profile)
-        highlights = HighlightSerializer(highlights, many=True)
+        paginator = self.pagination_class()
+        highlights_page = paginator.paginate_queryset(highlights, request)
+        highlights = self.serializer_class(highlights_page, many=True, context={'request': request})
+        paginated_highlights = paginator.get_paginated_response(highlights.data)
         return Response({
             'message': HIGHLIGHT_MSGS['HIGHLIGHTS_FOUND'],
-            'highlights': highlights.data
+            'highlights': paginated_highlights.data['results'],
+            'count': paginated_highlights.data['count'],
+            'next': paginated_highlights.data['next'],
+            'previous': paginated_highlights.data['previous']
         },
             status=status.HTTP_200_OK)
 
@@ -202,18 +279,34 @@ class UpdateMyHighlightsAPIView(APIView):
         # Retrieve the user from the request if they have been authenticated
         current_user = request.user
         highlight_data = request.data.get("highlight_data", {})
+        if "comment" not in highlight_data and "private" not in highlight_data:
+            return Response(
+                {
+                    "errors": HIGHLIGHT_MSGS["HIGHLIGHTS_COMMENT_OR_PRIVATE_FIELD_REQUIRED"]
+                },
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
         try:
             highlight = Highlights.objects.get(id=pk)
             self.check_object_permissions(request, obj=highlight)
+            # Check if we are changing the privacy setting of the highlight
+            if "private" in highlight_data and isinstance(highlight_data["private"], bool):
+                highlight.private = highlight_data["private"]
+            highlight.comment = highlight_data['comment']
             update_highlight = {
                 "article": highlight.article,
                 "profile": current_user.profile,
                 "start_index": highlight.start_index,
                 "end_index": highlight.end_index,
-                "comment": highlight_data['comment']
-
+                "comment": highlight.comment,
+                "private": highlight.private
             }
-            update_highlight = self.serializer_class(highlight, data=update_highlight, partial=True)
+            update_highlight = self.serializer_class(highlight, data=update_highlight,
+                                                     context={'article': update_highlight["article"],
+                                                              'profile': current_user.profile,
+                                                              'request': request},
+                                                     partial=True)
             update_highlight.is_valid(raise_exception=True)
             update_highlight.save()
             return Response({

--- a/authors/apps/profiles/models.py
+++ b/authors/apps/profiles/models.py
@@ -5,8 +5,6 @@ from django.db import models
 from django.db.models.signals import post_save
 
 from authors.apps.core.models import TimeStampModel
-from authors.apps.highlights.models import Highlights
-from authors.apps.highlights.serializers import HighlightSerializer
 
 
 class Profile(TimeStampModel):
@@ -55,11 +53,6 @@ class Profile(TimeStampModel):
     def followers(self):
         profiles = self.to_profile.all()
         return [profile.from_profile.user for profile in profiles]
-
-    @property
-    def highlights(self):
-        highlights = Highlights.objects.filter(profile=self)
-        return HighlightSerializer(highlights, many=True).data
 
 
 """

--- a/authors/apps/profiles/tests/test_models.py
+++ b/authors/apps/profiles/tests/test_models.py
@@ -91,10 +91,3 @@ class TestCustomFollow(TestCase):
             CustomFollows.objects.get,
             to_profile_id=self.user2_profile.id
         )
-
-    def test_user_can_get_their_highlights(self):
-        """
-        Test that a user can get their article highlights as a profile property
-        :return:
-        """
-        self.assertEqual([], self.user1_profile.highlights)

--- a/authors/apps/profiles/tests/test_views.py
+++ b/authors/apps/profiles/tests/test_views.py
@@ -4,7 +4,9 @@ from django.test import TestCase, Client
 from django.urls import reverse
 from rest_framework import status
 
+from authors.apps.articles.models import Articles
 from authors.apps.authentication.models import User
+from authors.apps.highlights.models import Highlights
 from authors.apps.profiles.models import CustomFollows
 from authors.apps.profiles.response_messages import (
     FOLLOW_USER_MSGS,
@@ -97,6 +99,19 @@ class TestProfileViews(TestCase):
         """ test for the retrieve my profile endpoint """
         token = self.login_a_user()
         headers = {'HTTP_AUTHORIZATION': 'Bearer ' + token}
+        new_article = Articles.objects.create(
+            title="Time in a tree.",
+            description="Raleigh Ritchie",
+            body="Stuck on repeat",
+            author=self.user
+        )
+        new_article.save()
+        Highlights.objects.create(
+            start_index=2,
+            end_index=8,
+            profile=self.user.profile,
+            article=new_article
+        ).save()
         response = self.test_client.get(
             reverse('profiles:my_profile'), **headers,
             content_type='application/json')
@@ -146,7 +161,6 @@ class TestProfileViews(TestCase):
         response = self.test_client.put(
             "/api/user/", **headers, content_type='application/json',
             data=json.dumps(self.errornious_updated_data))
-
         self.assertEqual(response.json()['errors']['profile']['website'], [
             "Enter a valid URL."])
 


### PR DESCRIPTION
### What does this PR do?
Ensures users can make their highlights public or private, allows users to view highlights of an article if they are public. Returns summary of highlights instead of specific highlight details on the profile data (`my_highlights` and `highlights_on_my_articles`)

### Description of tasks to be completed
Fix profile data to only show summary statistics rather than full details about articles on their profile. This is so we can reduce the amount of data returned when a user tries to retrieve their profile.
Also adds the privacy setting for a highlight - Users can now allow their highlight to be seen by others readers who are reading the article

### How should this be manually tested
1.  Clone the repository 
```https://github.com/andela/ah-centauri-backend.git```
2. On completing of cloning
```bash 
cd ah-centauri-backend
git checkout bug/165715944-fix-highlights-privacy
```

3. Install packages

`pipenv install`

4. Run migrations

`python manage.py makemigrations`
`python manage.py migrate`

5. Rename the .env.example file into .env and update the parameters with your own keys.

> For Centauri team members you can use the keys shared through slack

6. Start the development server and send the following through postman

`python manage.py runserver`

**Get my profile**
```

GET /api/profiles/me/
The current user retrieves their profile information (the profile will now display their highlights and all highlights made on their authored articles)
```

**Get my profile as the current user**
```

GET /api/highlights/
A user retrieves all their highlights
```

**Get all public highlights for an article**
```

GET /api/highlights/<slug:slug>/all/
A user retrieves all public highlights for an article
```

**Get all my highlights for an article**
```

GET /api/highlights/<slug:slug>/
A user retrieves all their highlights for an article
```

**Create a highlight for an article**
```

POST /api/highlights/<slug:slug>/
A user creates a highlight or deletes a highlight
```

**POST payload**
```
{
	"highlight_data": {
		"start_index":14,
		"end_index": 23,
		"comment": "New highlight comment",
	}
}
```

**Update the comment of a highlight for an article**
```

PUT /api/highlights/<int:pk>/
A user updates the comment they made to their highlight
```
**PUT payload**
```
{
	"highlight_data": {
		"comment": "New highlight comment",
                 "private": false
	}
}
```

### What are the relevant Pivotal Tracker stories?
[#165715944](https://www.pivotaltracker.com/story/show/165715944)

### Screenshots 
Changes to profile highlight details
![User profile highlights summaries](https://user-images.githubusercontent.com/31648893/57100252-1da4c300-6d27-11e9-8e69-578f660acbd6.png)

