### PR TITLE
bug(password reset): change redirect url when user clicks on password…

### DIFF
--- a/app.json
+++ b/app.json
@@ -9,6 +9,78 @@
   ],
   "description": "PR review app",
   "env": {
+    "ALLOWED_HOSTS": {
+      "required" : true
+    },
+    "CLOUDINARY_API_KEY": {
+      "required": true
+    },
+    "CLOUDINARY_API_SECRET": {
+      "required": true
+    },
+    "CLOUDINARY_CLOUD_NAME": {
+      "required": true
+    },
+    "CLOUDINARY_URL": {
+      "required": true
+    },
+    "CORS_ORIGIN_WHITELIST": {
+      "required" : true
+    },
+    "DATABASE_URL": {
+      "required": true
+    },
+    "DB_HOST": {
+      "required": true
+    },
+    "DB_NAME": {
+      "required": true
+    },
+    "DB_PASS": {
+      "required": true
+    },
+    "DB_PORT": {
+      "required": true
+    },
+    "DB_USER": {
+      "required": true
+    },
+    "DISABLE_COLLECTSTATIC": {
+      "required": true
+    },
+    "EMAIL_HOST": {
+      "required": true
+    },
+    "EMAIL_HOST_PASSWORD": {
+      "required": true
+    },
+    "EMAIL_HOST_USER": {
+      "required": true
+    },
+    "EMAIL_PORT": {
+      "required": true
+    },
+    "REACT_CLIENT_URL": {
+      "required": true
+    },
+    "SOCIAL_AUTH_FACEBOOK_KEY": {
+      "required": true
+    },
+    "SOCIAL_AUTH_FACEBOOK_SECRET": {
+      "required": true
+    },
+    "SOCIAL_AUTH_GOOGLE_OAUTH2_KEY": {
+      "required": true
+    },
+    "SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET": {
+      "required": true
+    },
+    "SOCIAL_AUTH_TWITTER_KEY": {
+      "required": true
+    },
+    "SOCIAL_AUTH_TWITTER_SECRET": {
+      "required": true
+    }
   },
   "formation": {
     "web": {

--- a/authors/apps/authentication/tests/test_views_password_reset.py
+++ b/authors/apps/authentication/tests/test_views_password_reset.py
@@ -42,7 +42,7 @@ class PasswordResetViewTest(TestCase):
 
     def test_valid_password_reset_request(self):
         """
-        Test if user can make a request to reset their password
+        Test if user can make a request to reset their password.
         """
         response = self.client.post(
             reverse('authentication:password_reset'),

--- a/authors/apps/authentication/utils.py
+++ b/authors/apps/authentication/utils.py
@@ -6,12 +6,12 @@ from django.conf import settings
 from django.core.mail import EmailMultiAlternatives
 from django.template.loader import render_to_string
 
-# Set the host url for the password reset link
-host_url = os.environ.get('AH_HOST_URL')
+# react url
+react_url = os.environ.get('REACT_CLIENT_URL')
 # Set the sender email for the password reset emails
 ah_centauri_sender_email = "ah.centauri@gmail.com"
 # Set the url path for a password reset
-password_reset_urlpath = "password_reset/"
+password_reset_urlpath = "reset/"
 
 
 class PasswordResetTokenHandler:
@@ -37,7 +37,7 @@ class PasswordResetTokenHandler:
             False - if the email was not sent.
         """
         # Create the password reset link to be sent in the email using the token.
-        password_reset_link = f"{request.scheme}://{request.get_host()}/" + password_reset_urlpath + token + "/"
+        password_reset_link = react_url + password_reset_urlpath + token + "/"
         email_details_context = {
             'username': user.username,
             'password_reset_link': password_reset_link


### PR DESCRIPTION
#### What does this PR do?
A user should be able to reset his/her password when he/she forgets it, or for any other reason. This PR fixes a bug where the redirect link pointed to the backend instead of redirecting the user to the frontend where he/she can reset their password.

#### Description of Tasks to be completed?
- change password reset redirect link 

#### Any background context you want to provide?
N/A

#### What are the relevant Pivotal Tracker Stories?
[#165878072](https://www.pivotaltracker.com/story/show/165878072)
