### PR TITLE
Bug(Fix URL for article social share links)

### DIFF
--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -1,19 +1,19 @@
+import os
 from urllib import parse
 
 import readtime
-from django.urls import reverse
-from rest_framework import serializers
 from django.contrib.auth.models import AnonymousUser
+from django.contrib.contenttypes.models import ContentType
+from rest_framework import serializers
 from taggit_serializer.serializers import (TagListSerializerField,
                                            TaggitSerializer, )
-from django.contrib.auth.models import AnonymousUser
+
 from authors.apps.articles.models import (Articles,
                                           Ratings,
                                           Favorite,
                                           ReportArticles, LikeDislike)
 from authors.apps.articles.utils import ChoicesField
 
-from django.contrib.contenttypes.models import ContentType
 
 class TagSerializer(TagListSerializerField):
     default_error_messages = {
@@ -64,7 +64,7 @@ class ArticleSerializer(TaggitSerializer, serializers.HyperlinkedModelSerializer
                                             vote=1)
 
         return bool(len(list(ld)))
-        
+
     def get_has_disliked(self, instance):
         """
         Handle checking if a user has disliked an article before
@@ -136,23 +136,18 @@ class ArticleSerializer(TaggitSerializer, serializers.HyperlinkedModelSerializer
             title = obj.title
             description = obj.description
 
-            article_link = reverse(
-                'articles:article', kwargs={'slug': obj.slug})
-
+            react_url = os.environ.get('REACT_CLIENT_URL')  # Get the react client URL
+            article_link = react_url + 'article/' + obj.slug
             request = self.context.get('request')
 
             if request:
-                article_link = parse.quote(
-                    request.build_absolute_uri(article_link))
+                article_link = parse.quote(article_link)
                 title = parse.quote(title)
                 description = parse.quote(description)
 
-                links['facebook'] = "https://www.facebook.com/sharer/sharer.php?u={}".format(
-                    article_link)
-                links['twitter'] = "https://twitter.com/intent/tweet?url={}&text={}".format(
-                    article_link, title)
-                links['email'] = "mailto:?&subject={}&body={}".format(
-                    title, description, article_link)
+                links['facebook'] = "https://www.facebook.com/sharer/sharer.php?u={}".format(article_link)
+                links['twitter'] = "https://twitter.com/intent/tweet?url={}&text={}".format(article_link, title)
+                links['email'] = "mailto:?&subject={}&body={}".format(title, description, article_link)
 
         # return whatever we now have in the :links dictionary
         return links


### PR DESCRIPTION
### What does this PR do?
Ensures social media share links for articles are based on the frontend URL. Not the backend API URL.

### Description of tasks to be completed
Social media share links should direct a user to the article page on the frontend. i.e They should be able to view the article as a webpage

### How should this be manually tested
1.  Clone the repository 
```https://github.com/andela/ah-centauri-backend.git```
2. On completing of cloning
```bash 
cd ah-centauri-backend
git checkout bug/166053017-fix-URL-articles-social-share
```

3. Install packages

`pipenv install`

4. Run migrations

`python manage.py makemigrations`
`python manage.py migrate`

5. Rename the .env.example file into .env and update the parameters with your own keys.

> For Centauri team members you can use the keys shared through slack

6. Start the development server and send the following through postman

`python manage.py runserver`


`GET /api/articles/`
Retrieve all the articles created

View the `share_links` property of the article as based on the frontend URL.

### What are the relevant Pivotal Tracker stories?
[#166053017](https://www.pivotaltracker.com/story/show/166053017)
