### PR TITLE
bug(Avatar image size fix)-User avatar image size 1:1 aspect ration

### DIFF
--- a/authors/apps/profiles/models.py
+++ b/authors/apps/profiles/models.py
@@ -46,7 +46,7 @@ class Profile(TimeStampModel):
     @property
     def get_cloudinary_url(self):
         image_url = CloudinaryImage(str(self.image)).build_url(
-            width=100, height=150, crop='fill')
+            width=400, height=400, crop='fill')
         return image_url
 
     @property

--- a/authors/apps/profiles/tests/test_views.py
+++ b/authors/apps/profiles/tests/test_views.py
@@ -175,7 +175,7 @@ class TestProfileViews(TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()['user']['profile']['image_url'],
-                         "https://res.cloudinary.com/daniel2019/image/upload/c_fill,h_150,w_100/dogs")
+                         "https://res.cloudinary.com/daniel2019/image/upload/c_fill,h_400,w_400/dogs")
 
     def test_if_one_can_upload_pdf_as_profile_image(self):
         """ test if an profile image uploads successfully """


### PR DESCRIPTION
### What does this PR do?
Adjusts the user profile image to make it fit a square or circular image appropriately

### Description of tasks to be completed
In order to ensure a user's avatar image is of 1:1 ratio the size of the width and height must be equal. This is because the avatar is displayed within a circular image which means it is important to make the aspect ratio fit, so as to not distort the circular avatar element.

### How should this be manually tested
1.  Clone the repository 
```https://github.com/andela/ah-centauri-backend.git```
2. On completing of cloning
```bash 
cd ah-centauri-backend
git checkout bug/165910006-fix-avatar-image-width-height
```

3. Install packages

`pipenv install`

4. Run migrations

`python manage.py makemigrations`
`python manage.py migrate`

5. Rename the .env.example file into .env and update the parameters with your own keys.

> For Centauri team members you can use the keys shared through slack

6. Start the development server and send the following through postman

`python manage.py runserver`

**Get my profile**
```

GET /api/profiles/me/
The current user retrieves their profile information (the profile will now have a default avatar with the 400x400 width and height (1:1 aspect ratio) a)
```



### What are the relevant Pivotal Tracker stories?
[#165910006](https://www.pivotaltracker.com/story/show/165910006)

